### PR TITLE
Fix/tao 4561 media drag drop

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -13,6 +13,7 @@
                           rootNode="http://www.tao.lu/Ontologies/TAOMedia.rdf#Media"
                           selectClass="media-class-properties"
                           selectInstance="media-properties"
+                          moveInstance="media-move"
                           delete="media-delete"
                             />
                 </trees>
@@ -29,6 +30,9 @@
                     <action id="media-delete" name="Delete" binding="removeNode" url="/taoMediaManager/MediaManager/delete"
                             context="resource" group="tree">
                         <icon id="icon-bin"/>
+                    </action>
+                    <action id="media-move" name="Move" url="/taoMediaManager/MediaManager/moveInstance" context="instance" group="none" binding="moveNode">
+                        <icon id="icon-move-item"/>
                     </action>
                     <action id="media-import" name="Import" url="/taoMediaManager/MediaImport/index" group="tree"
                             context="resource">

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'extension-tao-mediamanager',
     'description' => 'TAO media manager extension',
     'license' => 'GPL-2.0',
-    'version' => '2.0.0',
+    'version' => '2.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -221,6 +221,6 @@ class Updater extends \common_ext_ExtensionUpdater
 
         $this->setVersion($currentVersion);
 
-        $this->skip('0.3.0', '2.0.0');
+        $this->skip('0.3.0', '2.0.1');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4561

Allow to drag'n drop media from/to (sub)classes.

To test, install or update the extension `taoMediaManager`, then import some media. You should also create some classes. Once this setup is done, try to move media across classes...