### PR TITLE
Fix version of extension installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		},
 		"minimum-stability" : "dev",
 		"require": {
-			"oat-sa/oatbox-extension-installer": "dev-master"
+			"oat-sa/oatbox-extension-installer": "~1.1||dev-master"
 		},
 		"autoload" : {
 			"psr-4" : {


### PR DESCRIPTION
In order to raise the minimum-stability of a tao install, we need to be able to install the extension installer in a released version. To this end all extensions need to move from "oat-sa/oatbox-extension-installer:dev-master" to "oat-sa/oatbox-extension-installer:~1.1||dev-master". Details: https://oat-sa.atlassian.net/browse/TAO-6542