### PR TITLE
TAO-7830. Use externally given user on import to prevent calling sess…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,10 +27,10 @@ return array(
     'label' => 'extension-tao-mediamanager',
     'description' => 'TAO media manager extension',
     'license' => 'GPL-2.0',
-    'version' => '6.0.1',
+    'version' => '6.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'tao' => '>=27.2.0',
+        'tao' => '>=31.0.0',
         'generis' => '>=8.1.3',
         'taoItems' => '>=6.0.0'
     ),

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'extension-tao-mediamanager',
     'description' => 'TAO media manager extension',
     'license' => 'GPL-2.0',
-    'version' => '6.0.0',
+    'version' => '6.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=27.2.0',

--- a/model/FileImporter.php
+++ b/model/FileImporter.php
@@ -70,10 +70,11 @@ class FileImporter implements \tao_models_classes_import_ImportHandler, ServiceL
     /**
      * @param \core_kernel_classes_Class $class
      * @param Form|array $form
+     * @param string|null $userId owner of the resource
      * @return Report
      * @throws \common_exception_Error
      */
-    public function import($class, $form)
+    public function import($class, $form, $userId = null)
     {
         $uploadedFile = $this->fetchUploadedFile($form);
 
@@ -101,7 +102,9 @@ class FileImporter implements \tao_models_classes_import_ImportHandler, ServiceL
                         $uploadedFile,
                         $classUri,
                         \tao_helpers_Uri::decode($form instanceof Form ? $form->getValue('lang') : $form['lang']),
-                        $fileInfo['name']
+                        $fileInfo['name'],
+                        null,
+                        $userId
                     );
 
                     if (!$mediaResourceUri) {
@@ -117,7 +120,7 @@ class FileImporter implements \tao_models_classes_import_ImportHandler, ServiceL
                 } else {
                     $zipImporter = new ZipImporter();
                     $zipImporter->setServiceLocator($this->getServiceLocator());
-                    $report = $zipImporter->import($class, $form);
+                    $report = $zipImporter->import($class, $form, $userId);
                 }
             } else {
                 // editing existing media

--- a/model/MediaService.php
+++ b/model/MediaService.php
@@ -69,9 +69,10 @@ class MediaService extends \tao_models_classes_ClassService
      * @param string $language language of the content
      * @param string $label label of the instance
      * @param string $mimeType mimeType of the file
+     * @param string|null $userId owner of the resource
      * @return string | bool $instanceUri or false on error
      */
-    public function createMediaInstance($fileSource, $classUri, $language, $label = null, $mimeType = null)
+    public function createMediaInstance($fileSource, $classUri, $language, $label = null, $mimeType = null, $userId = null)
     {
         $clazz = $this->getClass($classUri);
 
@@ -98,7 +99,7 @@ class MediaService extends \tao_models_classes_ClassService
 
             if ($this->getServiceLocator()->get(common_ext_ExtensionsManager::SERVICE_ID)->isEnabled('taoRevision')) {
                 \common_Logger::i('Auto generating initial revision');
-                RevisionService::commit($instance, __('Initial import'));
+                RevisionService::commit($instance, __('Initial import'), null, $userId);
             }
             return $instance->getUri();
         }

--- a/model/SharedStimulusImporter.php
+++ b/model/SharedStimulusImporter.php
@@ -78,10 +78,11 @@ class SharedStimulusImporter implements \tao_models_classes_import_ImportHandler
      *
      * @param \core_kernel_classes_Class   $class
      * @param Form|array $form
+     * @param string|null $userId owner of the resource
      * @return Report $report
      * @throws \common_exception_NotAcceptable
      */
-    public function import($class, $form)
+    public function import($class, $form, $userId = null)
     {
         $uploadedFile = $this->fetchUploadedFile($form);
 
@@ -107,7 +108,8 @@ class SharedStimulusImporter implements \tao_models_classes_import_ImportHandler
                             $classUri,
                             \tao_helpers_Uri::decode($form instanceof Form ? $form->getValue('lang') : $form['lang']),
                             $fileInfo['name'],
-                            'application/qti+xml'
+                            'application/qti+xml',
+                            $userId
                         );
 
                         if (!$mediaResourceUri) {
@@ -127,7 +129,7 @@ class SharedStimulusImporter implements \tao_models_classes_import_ImportHandler
                     }
                 } else {
                     $this->getZipImporter()->setServiceLocator($this->getServiceLocator());
-                    $report = $this->getZipImporter()->import($class, $form);
+                    $report = $this->getZipImporter()->import($class, $form, $userId);
                 }
             } else {
                 if (!\helpers_File::isZipMimeType($fileInfo['type'])) {

--- a/model/SharedStimulusPackageImporter.php
+++ b/model/SharedStimulusPackageImporter.php
@@ -41,9 +41,10 @@ class SharedStimulusPackageImporter extends ZipImporter
      *
      * @param \core_kernel_classes_Class $class
      * @param Form|array $form
+     * @param string|null $userId owner of the resource
      * @return Report
      */
-    public function import($class, $form)
+    public function import($class, $form, $userId = null)
     {
         try {
             $uploadedFile = $this->fetchUploadedFile($form);
@@ -59,7 +60,7 @@ class SharedStimulusPackageImporter extends ZipImporter
 
             $report = Report::createSuccess(__('Shared Stimulus imported successfully'));
 
-            $subReport = $this->storeSharedStimulus($class, $this->getDecodedUri($form), $embeddedFile);
+            $subReport = $this->storeSharedStimulus($class, $this->getDecodedUri($form), $embeddedFile, $userId);
 
             $report->add($subReport);
         } catch (common_exception_UserReadableException $e) {
@@ -196,16 +197,17 @@ class SharedStimulusPackageImporter extends ZipImporter
      * @param \core_kernel_classes_Resource $class the class under which we will store the shared stimulus (can be an item)
      * @param string $lang language of the shared stimulus
      * @param string $xmlFile File to store
+     * @param string|null $userId owner of the resource
      * @return \common_report_Report
      *
      * @throws \qtism\data\storage\xml\XmlStorageException
      */
-    protected function storeSharedStimulus($class, $lang, $xmlFile)
+    protected function storeSharedStimulus($class, $lang, $xmlFile, $userId = null)
     {
         SharedStimulusImporter::isValidSharedStimulus($xmlFile);
 
         $service = MediaService::singleton();
-        if ($mediaResourceUri = $service->createMediaInstance($xmlFile, $class->getUri(), $lang, basename($xmlFile), 'application/qti+xml')) {
+        if ($mediaResourceUri = $service->createMediaInstance($xmlFile, $class->getUri(), $lang, basename($xmlFile), 'application/qti+xml', $userId)) {
             $report = Report::createSuccess(__('Imported %s', basename($xmlFile)));
             $report->setData(['uriResource' => $mediaResourceUri]);
         } else {

--- a/model/ZipImporter.php
+++ b/model/ZipImporter.php
@@ -45,9 +45,10 @@ class ZipImporter implements ServiceLocatorAwareInterface
      *
      * @param \core_kernel_classes_Class   $class
      * @param \tao_helpers_form_Form|array $form
+     * @param string|null $userId owner of the resource
      * @return \common_report_Report
      */
-    public function import($class, $form)
+    public function import($class, $form, $userId = null)
     {
         try {
             $uploadedFile = $this->fetchUploadedFile($form);
@@ -89,7 +90,7 @@ class ZipImporter implements ServiceLocatorAwareInterface
                         $classUri = $this->createClass($file->getPath());
                     }
 
-                    $mediaResourceUri = $service->createMediaInstance($file->getRealPath(), $classUri, $language, $file->getFilename());
+                    $mediaResourceUri = $service->createMediaInstance($file->getRealPath(), $classUri, $language, $file->getFilename(), null, $userId);
                     $report->add(Report::createSuccess(
                         __('Imported %s', substr($file->getRealPath(), strlen($directory))),
                         ['uriResource' => $mediaResourceUri] // 'uriResource' key is needed by javascript in tao/views/templates/form/import.tpl

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -34,6 +34,6 @@ class Updater extends \common_ext_ExtensionUpdater
             throw new \common_exception_NotImplemented('Updates from versions prior to Tao 3.1 are not longer supported, please update to Tao 3.1 first');
         }
 
-        $this->skip('0.3.0', '6.0.0');
+        $this->skip('0.3.0', '6.0.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -34,6 +34,6 @@ class Updater extends \common_ext_ExtensionUpdater
             throw new \common_exception_NotImplemented('Updates from versions prior to Tao 3.1 are not longer supported, please update to Tao 3.1 first');
         }
 
-        $this->skip('0.3.0', '6.0.1');
+        $this->skip('0.3.0', '6.1.0');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7830

When importing files, this fix makes import functions (wrappers between the task runner and the Revision committer) to use given user IDs instead of calling SessionManager inside the Revision committer.