### PR TITLE
UDI-157: Media files don't get uploaded when `taoRevision` is enabled

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'label' => 'extension-tao-mediamanager',
     'description' => 'TAO media manager extension',
     'license' => 'GPL-2.0',
-    'version' => '9.2.0',
+    'version' => '9.2.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=34.0.0',

--- a/model/MediaService.php
+++ b/model/MediaService.php
@@ -26,8 +26,8 @@ use oat\generis\model\OntologyAwareTrait;
 use oat\generis\model\OntologyRdfs;
 use oat\oatbox\filesystem\File;
 use common_ext_ExtensionsManager;
-use oat\taoRevision\model\Repository;
 use oat\taoMediaManager\model\fileManagement\FileManagement;
+use oat\taoRevision\model\RepositoryInterface;
 
 /**
  * Service methods to manage the Media
@@ -100,7 +100,7 @@ class MediaService extends \tao_models_classes_ClassService
 
             if ($this->getServiceLocator()->get(common_ext_ExtensionsManager::SERVICE_ID)->isEnabled('taoRevision')) {
                 \common_Logger::i('Auto generating initial revision');
-                $this->getServiceLocator()->get(Repository::SERVICE_ID)->commit($instance->getUri(), __('Initial import'), null, $userId);
+                $this->getServiceLocator()->get(RepositoryInterface::SERVICE_ID)->commit($instance, __('Initial import'), null, $userId);
             }
             return $instance->getUri();
         }
@@ -136,7 +136,7 @@ class MediaService extends \tao_models_classes_ClassService
 
             if ($this->getServiceLocator()->get(common_ext_ExtensionsManager::SERVICE_ID)->isEnabled('taoRevision')) {
                 \common_Logger::i('Auto generating revision');
-                $this->getServiceLocator()->get(Repository::SERVICE_ID)->commit($instance->getUri(), __('Imported new file'), null, $userId);
+                $this->getServiceLocator()->get(RepositoryInterface::SERVICE_ID)->commit($instance, __('Imported new file'), null, $userId);
             }
         }
         return ($link !== false) ? true : false;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -35,6 +35,6 @@ class Updater extends \common_ext_ExtensionUpdater
             throw new \common_exception_NotImplemented('Updates from versions prior to Tao 3.1 are not longer supported, please update to Tao 3.1 first');
         }
 
-        $this->skip('0.3.0', '9.2.0');
+        $this->skip('0.3.0', '9.2.1');
     }
 }


### PR DESCRIPTION
- UDI-157 fix(media): use a correct `taoRevision` repository reference in `MediaService` when registering a new media file upload
- UDI-157 chore(version): bump