### PR TITLE
Feature/replicate item tree structure into media manager

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,11 +28,11 @@ return [
     'label' => 'extension-tao-mediamanager',
     'description' => 'TAO media manager extension',
     'license' => 'GPL-2.0',
-    'version' => '9.2.1',
+    'version' => '9.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=34.0.0',
-        'generis' => '>=12.15.0',
+        'generis' => '>=12.17.0',
         'taoItems' => '>=6.0.0'
     ],
     'models' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -35,6 +35,6 @@ class Updater extends \common_ext_ExtensionUpdater
             throw new \common_exception_NotImplemented('Updates from versions prior to Tao 3.1 are not longer supported, please update to Tao 3.1 first');
         }
 
-        $this->skip('0.3.0', '9.2.1');
+        $this->skip('0.3.0', '9.3.0');
     }
 }


### PR DESCRIPTION
This PR adds the possibility to specify several levels of tree structure to create in the media manager in one call.
The idea behind is to be able to reproduce the tree structure of the item bank in which a set of items with a shared stimulus is imported.

Requires https://github.com/oat-sa/generis/pull/763
Required by https://github.com/oat-sa/extension-tao-itemqti/pull/1422