### PR TITLE
Export media as base64

### DIFF
--- a/controller/MediaManager.php
+++ b/controller/MediaManager.php
@@ -98,7 +98,7 @@ class MediaManager extends \tao_actions_SaSModule
 
         $fileManagement = $this->getServiceLocator()->get(FileManagement::SERVICE_ID);
         $stream = $fileManagement->getFileStream($fileInfo['link']);
-        if ($fileInfo['mime'] === 'application/qti+xml') {
+        if ($fileInfo['mime'] === MediaService::SHARED_STIMULUS_MIME_TYPE) {
             $this->response = $this->getPsrResponse()->withBody($stream);
         } elseif ($this->hasGetParameter('xml')) {
             $this->returnJson(htmlentities((string)$stream));

--- a/model/ImportHandlerFactory.php
+++ b/model/ImportHandlerFactory.php
@@ -52,7 +52,7 @@ class ImportHandlerFactory extends ConfigurableService
 
             $mimeType = $class->getProperty('http://www.tao.lu/Ontologies/TAOMedia.rdf#mimeType');
 
-            return (string)$class->getOnePropertyValue($mimeType) === 'application/qti+xml';
+            return (string)$class->getOnePropertyValue($mimeType) === MediaService::SHARED_STIMULUS_MIME_TYPE;
         } catch (Throwable $exception) {
             return false;
         }

--- a/model/MediaService.php
+++ b/model/MediaService.php
@@ -62,6 +62,8 @@ class MediaService extends ConfigurableService
 
     public const PROPERTY_MIME_TYPE = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#mimeType';
 
+    public const SHARED_STIMULUS_MIME_TYPE = 'application/qti+xml';
+
     /**
      * @deprecated 
      */
@@ -224,7 +226,7 @@ class MediaService extends ConfigurableService
         if ($container instanceof core_kernel_classes_Literal) {
             $mimeType = (string)$container;
 
-            return  $mimeType === 'application/qti+xml' ? $mimeType : null;
+            return  $mimeType === MediaService::SHARED_STIMULUS_MIME_TYPE ? $mimeType : null;
         }
 
         return null;

--- a/model/SharedStimulusImporter.php
+++ b/model/SharedStimulusImporter.php
@@ -122,7 +122,7 @@ class SharedStimulusImporter extends ConfigurableService implements
                             $classUri,
                             \tao_helpers_Uri::decode($form instanceof Form ? $form->getValue('lang') : $form['lang']),
                             $fileInfo['name'],
-                            'application/qti+xml',
+                            MediaService::SHARED_STIMULUS_MIME_TYPE,
                             $userId
                         );
 

--- a/model/SharedStimulusPackageImporter.php
+++ b/model/SharedStimulusPackageImporter.php
@@ -222,7 +222,7 @@ class SharedStimulusPackageImporter extends ZipImporter
             $class->getUri(),
             $lang,
             basename($xmlFile),
-            'application/qti+xml',
+            MediaService::SHARED_STIMULUS_MIME_TYPE,
             $userId
         );
 

--- a/model/ZipExporter.php
+++ b/model/ZipExporter.php
@@ -22,12 +22,25 @@
 
 namespace oat\taoMediaManager\model;
 
+use common_Exception;
 use common_report_Report as Report;
 use core_kernel_classes_Class;
+use core_kernel_classes_Container;
+use core_kernel_classes_EmptyProperty;
+use core_kernel_classes_Literal;
 use core_kernel_classes_Resource;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\log\LoggerService;
 use oat\oatbox\service\ServiceManager;
+use oat\tao\model\media\TaoMediaException;
+use oat\tao\model\media\TaoMediaResolver;
 use oat\taoMediaManager\model\fileManagement\FileManagement;
+use oat\taoQtiItem\model\qti\Parser;
+use qtism\data\content\xhtml\Img;
+use qtism\data\storage\xml\XmlDocument;
+use tao_helpers_Export;
 use tao_helpers_form_Form;
+use ZipArchive;
 
 /**
  * Service methods to manage the Media
@@ -38,6 +51,8 @@ use tao_helpers_form_Form;
  */
 class ZipExporter implements \tao_models_classes_export_ExportHandler
 {
+    use OntologyAwareTrait;
+
     /**
      * Returns a textual description of the import format
      *
@@ -64,7 +79,7 @@ class ZipExporter implements \tao_models_classes_export_ExportHandler
      * @param array  $formValues
      * @param string $destPath
      * @return \common_report_Report|null|string
-     * @throws \common_Exception
+     * @throws common_Exception
      * @throws \common_exception_Error
      */
     public function export($formValues, $destPath)
@@ -85,6 +100,7 @@ class ZipExporter implements \tao_models_classes_export_ExportHandler
         if ($class->isClass()) {
             $subClasses = $class->getSubClasses(true);
             $exportData = [$class->getLabel() => $class->getInstances()];
+
             foreach ($subClasses as $subClass) {
                 $instances = $subClass->getInstances();
                 $exportData[$subClass->getLabel()] = $instances;
@@ -92,6 +108,7 @@ class ZipExporter implements \tao_models_classes_export_ExportHandler
                 //get Class path
                 $parents = $subClass->getParentClasses();
                 $parent = array_shift($parents);
+
                 if (array_key_exists($parent->getLabel(), $exportClasses)) {
                     $exportClasses[$subClass->getLabel()] = $exportClasses[$parent->getLabel()] . '/' . $subClass->getLabel();
                 } else {
@@ -128,37 +145,46 @@ class ZipExporter implements \tao_models_classes_export_ExportHandler
 
     protected function createZipFile($filename, array $exportClasses = [], array $exportFiles = [])
     {
-        $zip = new \ZipArchive();
-        $baseDir = \tao_helpers_Export::getExportPath();
+        $zip = new ZipArchive();
+        $baseDir = tao_helpers_Export::getExportPath();
         $path = $baseDir . '/' . $filename . '.zip';
 
-        if ($zip->open($path, \ZipArchive::CREATE) !== true) {
-            throw new \common_Exception('Unable to create zipfile ' . $path);
+        if ($zip->open($path, ZipArchive::CREATE) !== true) {
+            throw new common_Exception('Unable to create zipfile ' . $path);
         }
 
         if ($zip->numFiles === 0) {
             $nbFiles = 0;
             foreach ($exportFiles as $label => $files) {
                 $archivePath = '';
-                /** @var $class \core_kernel_classes_Class */
+
+                /** @var $class core_kernel_classes_Class */
                 if (array_key_exists($label, $exportClasses)) {
                     $archivePath = $exportClasses[$label] . '/';
+
                     $zip->addEmptyDir($archivePath);
+
                     $nbFiles++;
                 }
+
                 $nbFiles += count($files);
                 //create the directory
 
+                /** @var core_kernel_classes_Resource $file */
                 foreach ($files as $file) {
-                    //add each file in the correct directory
-                    $link = $file->getUniquePropertyValue(new \core_kernel_classes_Property(MediaService::PROPERTY_LINK));
-                    if ($link instanceof \core_kernel_classes_Literal) {
-                        $link = $link->literal;
-                    }
+                    $link = $this->getResourceLink($file);
 
-                    /** @var FileManagement $fileManagement */
-                    $fileManagement = $this->getServiceManager()->get(FileManagement::SERVICE_ID);
-                    $zip->addFromString($archivePath . $file->getLabel(), $fileManagement->getFileStream($link)->getContents());
+                    $fileContents = $this->getFileManagement()
+                        ->getFileStream($link)
+                        ->getContents();
+
+                    //FIXME
+                    //FIXME
+                    $this->parseImages($fileContents);
+                    //FIXME
+                    //FIXME
+
+                    $zip->addFromString($archivePath . $file->getLabel(), $fileContents);
                 }
             }
         }
@@ -171,5 +197,77 @@ class ZipExporter implements \tao_models_classes_export_ExportHandler
     public function getServiceManager()
     {
         return ServiceManager::getServiceManager();
+    }
+
+    private function parseImages(string $fileContents)
+    {
+        $mediaResolver = new TaoMediaResolver();
+
+        /** @var LoggerService $logger */
+        $logger = $this->getServiceManager()->get(LoggerService::SERVICE_ID);
+
+        $logger->logCritical('================> EXPORTING ' . $fileContents);
+
+        $xmlDocument = new XmlDocument();
+        $xmlDocument->loadFromString($fileContents);
+
+        $images = $xmlDocument->getDocumentComponent()->getComponentsByClassName('img');
+
+        /** @var Img $image */
+        foreach ($images as $image) {
+            try {
+                $mediaAsset = $mediaResolver->resolve($image->getSrc());
+
+                if ($mediaAsset->getMediaSource() instanceof MediaSource) {
+                    $logger->logCritical('================>> IMAGE ' . $image->getSrc());
+
+                    $mediaResource = $this->getResource($mediaAsset->getMediaIdentifier());
+
+                    $link = $this->getResourceLink($mediaResource);
+
+                    $stream = $this->getFileManagement()->getFileStream($link);
+                }
+            } catch (TaoMediaException $exception) {
+            }
+        }
+    }
+
+    private function secureEncode($basedir, $source): string
+    {
+        $components = parse_url($source);
+        if (!isset($components['scheme'])) {
+            // relative path
+            if (\tao_helpers_File::securityCheck($source, false)) {
+                if (file_exists($basedir . $source)) {
+                    return 'data:' . \tao_helpers_File::getMimeType($basedir . $source) . ';'
+                        . 'base64,' . base64_encode(file_get_contents($basedir . $source));
+                } else {
+                    throw new \tao_models_classes_FileNotFoundException($source);
+                }
+            } else {
+                throw new \common_exception_Error('Invalid source path "' . $source . '"');
+            }
+        } else {
+            // url, just return it as is
+            return $source;
+        }
+    }
+
+    private function getFileManagement(): FileManagement
+    {
+        return $this->getServiceManager()->get(FileManagement::SERVICE_ID);
+    }
+
+    /**
+     * @return core_kernel_classes_Container|string
+     *
+     * @throws core_kernel_classes_EmptyProperty
+     * @throws common_Exception
+     */
+    private function getResourceLink(core_kernel_classes_Resource $resource)
+    {
+        $link = $resource->getUniquePropertyValue(new \core_kernel_classes_Property(MediaService::PROPERTY_LINK));
+
+        return $link instanceof core_kernel_classes_Literal ? $link->literal : $link;
     }
 }

--- a/model/export/service/MediaResourcePreparer.php
+++ b/model/export/service/MediaResourcePreparer.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoMediaManager\model\export\service;
+
+use core_kernel_classes_Resource;
+use Exception;
+use LogicException;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\log\LoggerAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\media\MediaAsset;
+use oat\tao\model\media\TaoMediaException;
+use oat\tao\model\media\TaoMediaResolver;
+use oat\taoMediaManager\model\fileManagement\FileManagement;
+use oat\taoMediaManager\model\MediaSource;
+use oat\taoMediaManager\model\sharedStimulus\specification\SharedStimulusResourceSpecification;
+use qtism\data\content\BodyElement;
+use qtism\data\content\xhtml\Img;
+use qtism\data\content\xhtml\QtiObject;
+use qtism\data\storage\xml\XmlDocument;
+
+class MediaResourcePreparer extends ConfigurableService
+{
+    use OntologyAwareTrait;
+    use LoggerAwareTrait;
+
+    private const PROCESS_XML_ELEMENTS = [
+        'img',
+        'object',
+    ];
+
+    /** @var TaoMediaResolver */
+    private $mediaResolver;
+
+    public function prepare(core_kernel_classes_Resource $mediaResource, string $contents): string
+    {
+        if (!$this->getSharedStimulusResourceSpecification()->isSatisfiedBy($mediaResource)) {
+            return $contents;
+        }
+
+        //@FIXME @TODO Logger will be removed from here
+        $this->logDebug('================> EXPORTING ' . $contents);
+        //@FIXME @TODO Logger will be removed from here
+
+        $xmlDocument = new XmlDocument();
+        $xmlDocument->loadFromString($contents);
+
+        foreach ($this->getComponents($xmlDocument) as $component) {
+            $mediaAsset = $this->getMediaAsset($component);
+
+            if (!$mediaAsset) {
+                continue;
+            }
+
+            //@FIXME @TODO Logger will be removed from here
+            $this->logDebug('================>> ELEMENT SOURCE: ' . $mediaAsset->getMediaIdentifier());
+            //@FIXME @TODO Logger will be removed from here
+
+            $this->replaceComponentPath($component, $mediaAsset);
+        }
+
+        return $xmlDocument->saveToString();
+    }
+
+    private function replaceComponentPath(BodyElement $component, MediaAsset $mediaAsset): void
+    {
+        $mediaSource = $mediaAsset->getMediaSource();
+
+        $fileInfo = $mediaSource->getFileInfo($mediaAsset->getMediaIdentifier());
+
+        $stream = $this->getFileManagement()->getFileStream($fileInfo['link']);
+
+        $contents = $stream->getContents();
+
+        $base64Content = $this->base64Encode($fileInfo['mime'], $contents);
+
+        $this->setComponentSource($component, $base64Content);
+    }
+
+    public function withMediaResolver(TaoMediaResolver $mediaResolver): self
+    {
+        $this->mediaResolver = $mediaResolver;
+
+        return $this;
+    }
+
+    private function getMediaResolver(): TaoMediaResolver
+    {
+        if (!$this->mediaResolver) {
+            return $this->mediaResolver = new TaoMediaResolver();
+        }
+
+        return $this->mediaResolver;
+    }
+
+    /**
+     * @return BodyElement[]
+     */
+    private function getComponents(XmlDocument $xmlDocument): array
+    {
+        $components = [];
+
+        foreach (self::PROCESS_XML_ELEMENTS as $element) {
+            $components = array_merge(
+                $components,
+                $xmlDocument->getDocumentComponent()
+                    ->getComponentsByClassName($element)
+                    ->getArrayCopy()
+            );
+        }
+
+        return $components;
+    }
+
+    private function getComponentSource(BodyElement $element): string
+    {
+        if ($element instanceof Img) {
+            return $element->getSrc();
+        }
+
+        if ($element instanceof QtiObject) {
+            return $element->getData();
+        }
+
+        throw new LogicException(sprintf('Body element [%s] not supported', get_class($element)));
+    }
+
+    private function setComponentSource(BodyElement $element, string $source): void
+    {
+        if ($element instanceof Img) {
+            $element->setSrc($source);
+        }
+
+        if ($element instanceof QtiObject) {
+            $element->setData($source);
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function getMediaAsset(BodyElement $component): ?MediaAsset
+    {
+        try {
+            $source = $this->getComponentSource($component);
+
+            $mediaAsset = $this->getMediaResolver()
+                ->resolve($source);
+
+            $mediaSource = $mediaAsset->getMediaSource();
+
+            return $mediaSource instanceof MediaSource ? $mediaAsset : null;
+        } catch (TaoMediaException $exception) {
+            return null;
+        }
+    }
+
+    private function base64Encode(string $mimeType, string $content): string
+    {
+        return 'data:' . $mimeType . ';base64,' . base64_encode($content);
+    }
+
+    private function getFileManagement(): FileManagement
+    {
+        return $this->getServiceManager()->get(FileManagement::SERVICE_ID);
+    }
+
+    private function getSharedStimulusResourceSpecification(): SharedStimulusResourceSpecification
+    {
+        return $this->getServiceLocator()->get(SharedStimulusResourceSpecification::class);
+    }
+}

--- a/model/relation/event/MediaSavedEventDispatcher.php
+++ b/model/relation/event/MediaSavedEventDispatcher.php
@@ -25,6 +25,7 @@ namespace oat\taoMediaManager\model\relation\event;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\service\ConfigurableService;
+use oat\taoMediaManager\model\MediaService;
 use oat\taoMediaManager\model\sharedStimulus\parser\SharedStimulusMediaExtractor;
 use tao_helpers_File;
 
@@ -59,7 +60,7 @@ class MediaSavedEventDispatcher extends ConfigurableService
 
     private function isSharedStimulus($mimeType): bool
     {
-        return $mimeType === 'application/qti+xml';
+        return $mimeType === MediaService::SHARED_STIMULUS_MIME_TYPE;
     }
 
     private function getEventManager(): EventManager

--- a/model/sharedStimulus/service/CreateService.php
+++ b/model/sharedStimulus/service/CreateService.php
@@ -29,6 +29,7 @@ use ErrorException;
 use oat\generis\model\data\Ontology;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\upload\UploadService;
+use oat\taoMediaManager\model\MediaService;
 use oat\taoMediaManager\model\sharedStimulus\CreateCommand;
 use oat\taoMediaManager\model\sharedStimulus\SharedStimulus;
 use oat\taoMediaManager\model\SharedStimulusImporter;
@@ -74,7 +75,7 @@ class CreateService extends ConfigurableService
                     'lang' => $command->getLanguageId(),
                     'source' => [
                         'name' => $sharedStimulusName,
-                        'type' => 'application/qti+xml',
+                        'type' => MediaService::SHARED_STIMULUS_MIME_TYPE,
                     ],
                     'uploaded_file' => DIRECTORY_SEPARATOR
                         . $uploadService->getUserDirectoryHash()

--- a/model/sharedStimulus/specification/SharedStimulusResourceSpecification.php
+++ b/model/sharedStimulus/specification/SharedStimulusResourceSpecification.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoMediaManager\model\sharedStimulus\specification;
+
+use common_Exception;
+use core_kernel_classes_EmptyProperty;
+use core_kernel_classes_Literal;
+use core_kernel_classes_Resource;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoMediaManager\model\MediaService;
+
+class SharedStimulusResourceSpecification extends ConfigurableService
+{
+    use OntologyAwareTrait;
+
+    /**
+     * @throws common_Exception
+     */
+    public function isSatisfiedBy(core_kernel_classes_Resource $resource): bool
+    {
+        try {
+            $propertyValue = $resource->getUniquePropertyValue($this->getProperty(MediaService::PROPERTY_MIME_TYPE));
+
+            if ($propertyValue instanceof core_kernel_classes_Literal) {
+                return $propertyValue->literal === MediaService::SHARED_STIMULUS_MIME_TYPE;
+            }
+        } catch (core_kernel_classes_EmptyProperty $exception) {
+        }
+
+        return false;
+    }
+}

--- a/test/unit/model/relation/event/MediaSavedEventDispatcherTest.php
+++ b/test/unit/model/relation/event/MediaSavedEventDispatcherTest.php
@@ -25,6 +25,7 @@ namespace oat\taoMediaManager\test\unit\model\relation\event;
 use oat\generis\test\TestCase;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\filesystem\File;
+use oat\taoMediaManager\model\MediaService;
 use oat\taoMediaManager\model\relation\event\MediaSavedEvent;
 use oat\taoMediaManager\model\relation\event\MediaSavedEventDispatcher;
 use oat\taoMediaManager\model\sharedStimulus\parser\SharedStimulusMediaExtractor;
@@ -67,7 +68,7 @@ class MediaSavedEventDispatcherTest extends TestCase
     public function testDispatchFromContent(): void
     {
         $id = 'fixture-id';
-        $mimeType = 'application/qti+xml';
+        $mimeType = MediaService::SHARED_STIMULUS_MIME_TYPE;
         $content = 'fixture-content';
 
         $fixtureIds = ['media-1', 'media-2'];
@@ -121,7 +122,7 @@ class MediaSavedEventDispatcherTest extends TestCase
         $fileSource = $this->createMock(File::class);
         $fileSource->expects($this->once())
             ->method('getMimeType')
-            ->willReturn('application/qti+xml');
+            ->willReturn(MediaService::SHARED_STIMULUS_MIME_TYPE);
 
         $fileSource->expects($this->once())
             ->method('read')

--- a/test/unit/model/sharedStimulus/service/CreateServiceTest.php
+++ b/test/unit/model/sharedStimulus/service/CreateServiceTest.php
@@ -28,6 +28,7 @@ use ErrorException;
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\tao\model\upload\UploadService;
+use oat\taoMediaManager\model\MediaService;
 use oat\taoMediaManager\model\sharedStimulus\CreateCommand;
 use oat\taoMediaManager\model\sharedStimulus\service\CreateService;
 use oat\taoMediaManager\model\sharedStimulus\SharedStimulus;
@@ -113,7 +114,7 @@ class CreateServiceTest extends TestCase
                     'lang' => self::LANGUAGE_URI,
                     'source' => [
                         'name' => self::NAME,
-                        'type' => 'application/qti+xml',
+                        'type' => MediaService::SHARED_STIMULUS_MIME_TYPE,
                     ],
                     'uploaded_file' => DIRECTORY_SEPARATOR
                         . self::USER_DIRECTORY_HASH


### PR DESCRIPTION
- Export media as base64 instead of remove media path

Ps:

- Other medias like video, audio, pdf are not working properly with base64. This is a production bug, so the focus here were about images.
- No tests added / fixe until we team agrees with the solution.

https://oat-sa.atlassian.net/browse/NEX-1203