### PR TITLE
Add possibility to process encoded video on shared stimulus embedded assets

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,10 +28,10 @@ return [
     'label' => 'extension-tao-mediamanager',
     'description' => 'TAO media manager extension',
     'license' => 'GPL-2.0',
-    'version' => '11.3.1',
+    'version' => '11.4.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
-        'tao' => '>=44.12.0',
+        'tao' => '>=45.2.0',
         'generis' => '>=12.33.0',
         'taoItems' => '>=10.6.2',
         'taoQtiItem' => '>=25.3.4',

--- a/model/sharedStimulus/parser/SharedStimulusMediaParser.php
+++ b/model/sharedStimulus/parser/SharedStimulusMediaParser.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoMediaManager\model\sharedStimulus\parser;
 
+use oat\tao\helpers\Base64;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\media\TaoMediaException;
 use oat\tao\model\media\TaoMediaResolver;
@@ -82,7 +83,7 @@ class SharedStimulusMediaParser extends ConfigurableService
 
     private function processMediaSource(string $uri, callable $processor, array &$matches): void
     {
-        if (false === strpos($uri, 'data:image')) {
+        if (!Base64::isEncoded($uri)) {
 
             if (isset(parse_url($uri)['scheme'])) {
                 $asset = $this->getMediaResolver()->resolve($uri);

--- a/test/unit/model/sharedStimulus/parser/SharedStimulusMediaParserTest.php
+++ b/test/unit/model/sharedStimulus/parser/SharedStimulusMediaParserTest.php
@@ -48,7 +48,8 @@ class SharedStimulusMediaParserTest extends TestCase
     public function testExtractMedia()
     {
         $imagePath = 'taomedia://taomediamanager/image-path.png';
-        $imageDataUri = 'data:image/png;' . base64_encode('base64-content');
+        $imageDataUri = 'data:image/png;base64' . base64_encode('base64-image');
+        $imageDataUri = 'data:video/mp4;base64' . base64_encode('base64-video');
         $objectPath = 'taomedia://taomediamanager/video-path.mp4';
         $objectHttp = 'http://video.tao';
 


### PR DESCRIPTION
Problem.

When importing item with shared stimulus which contains video the import fails.
To test use item found on [TAO-10460](https://oat-sa.atlassian.net/browse/TAO-10460)
