### PR TITLE
Fix broken unit test in SharedStimulusMediaParserTest

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'label' => 'extension-tao-mediamanager',
     'description' => 'TAO media manager extension',
     'license' => 'GPL-2.0',
-    'version' => '11.4.0',
+    'version' => '11.4.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=45.2.0',

--- a/test/unit/model/sharedStimulus/parser/SharedStimulusMediaParserTest.php
+++ b/test/unit/model/sharedStimulus/parser/SharedStimulusMediaParserTest.php
@@ -92,10 +92,11 @@ class SharedStimulusMediaParserTest extends TestCase
 
     public function testExtractMediaWithInvalidQtiXml()
     {
-        $xml = '<?xml version="1.0" encoding="UTF-8"?><div><img src="fixture.tao"/></div>';
+        // missing closing div element (</div>)
+        $invalidXml = '<?xml version="1.0" encoding="UTF-8"?><div><img src="fixture.tao"/>';
 
         $this->expectException(TaoMediaException::class);
-        $this->subject->extractMedia($xml, function () {});
+        $this->subject->extractMedia($invalidXml, function () {});
     }
 
     private function createMediaAsset(string $path, string $sourceClass): MediaAsset


### PR DESCRIPTION
Fixing broken unit test in `SharedStimulusMediaParserTest`:
this PR changes a valid XML string to **invalid** to raise exception in SUT to cover expected scenario of invalid input. 