### PR TITLE
Reduced queries count to RDS while building media tree

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'extension-tao-mediamanager',
     'description' => 'TAO media manager extension',
     'license' => 'GPL-2.0',
-    'version' => '5.0.3',
+    'version' => '5.0.3.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=22.6.2',


### PR DESCRIPTION
Measures to improve https://oat-sa.atlassian.net/browse/CON-111

Sample request `http://depp-authoring.docker.localhost/taoItems/ItemContent/files?path=taomedia%3A%2F%2Fmediamanager%2F&uri=https%3A%2F%2Fdepp-auth.taocloud.org%2Ftao.rdf%23i16049178955445394934&lang=en-US&filters=video%2Fmp4%2Cvideo%2Favi%2Cvideo%2Fogv%2Cvideo%2Fmpeg%2Cvideo%2Fogg%2Cvideo%2Fquicktime%2Cvideo%2Fwebm%2Cvideo%2Fx-ms-wmv%2Cvideo%2Fx-flv%2Caudio%2Fmp3%2Caudio%2Fvnd.wav%2Caudio%2Fogg%2Caudio%2Fvorbis%2Caudio%2Fwebm%2Caudio%2Fmpeg%2Capplication%2Fogg%2Caudio%2Faac%2Caudio%2Fwav%2Caudio%2Fflac` 

Tested  with `5372` media files in library
before change  - `26711` queries 
after change - `2952` queries 