### PR TITLE
Fix/CON-238/reset settings in media after changing source

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'label' => 'extension-tao-mediamanager',
     'description' => 'TAO media manager extension',
     'license' => 'GPL-2.0',
-    'version' => '11.8.0',
+    'version' => '11.8.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=46.14.0',


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-238

Fixed reset of width in object after changing source.

How to test:

- go to Item Authoring
- create item with A-block and object contained video with width 50% for example
- save go to Items page
- return to item Authoring
- change source in object to image
- width should be reseted