### PR TITLE
fix: remove sample data with tricky name caused issues for developers on MacOS

### DIFF
--- a/test/integration/model/SharedStimulusPackageImporterTest.php
+++ b/test/integration/model/SharedStimulusPackageImporterTest.php
@@ -203,7 +203,6 @@ class SharedStimulusPackageImporterTest extends TestCase
             [$sampleDir . 'encodedImage.zip', 'zip', true],
             [$sampleDir . 'stimulusPackage.zip', 'xml', false],
             [$sampleDir . 'interactions.xml', '', false],
-            [$sampleDir . 'Й_wrongFilename.txt', 'css', false],
             ['php://stdout', 'extension', false]
         ];
     }


### PR DESCRIPTION
This fix issue with unzipping file from git under MacOS.
Issue was found by @bartlomiejmarszal testing locally the deployment PR: https://github.com/oat-sa/udir-deploy/pull/66