### PR TITLE
fix: remove on/off sections toggling in passage authoring

### DIFF
--- a/views/js/qtiCreator/editor/interactionsPanel.js
+++ b/views/js/qtiCreator/editor/interactionsPanel.js
@@ -56,9 +56,6 @@ define([
 
         // init accordions
         panel.initSidebarAccordion($container);
-        panel.closeSections($container.find('section'));
-        panel.openSections($container.find('#sidebar-left-section-inline-interactions'), false);
-
         // init special subgroup
         panel.toggleInlineInteractionGroup();
     };


### PR DESCRIPTION
Possible hotfix for https://oat-sa.atlassian.net/browse/AUT-767

There is more enhanced way to fix it (actually remove translation for id). It would be more stable in long-term, but might bring regressions in short-term. So if possible, I'd go with this hotfix for now and create a tech-debt ticket to remove translation from id. 