### PR TITLE
feat/AUT-738/ preview passage in Assets

### DIFF
--- a/views/js/controller/editInstance.js
+++ b/views/js/controller/editInstance.js
@@ -28,7 +28,8 @@ define([
     'taoMediaManager/previewer/component/qtiSharedStimulusItem',
     'core/logger',
     'ui/feedback',
-], function($, _, binder, previewer, urlUtil, qtiItemPreviewerFactory, loggerFactory, feedback) {
+    'layout/loading-bar'
+], function($, _, binder, previewer, urlUtil, qtiItemPreviewerFactory, loggerFactory, feedback, loadingBar) {
     'use strict';
 
     const logger = loggerFactory('taoMediaManager/editInstance');
@@ -50,13 +51,15 @@ define([
                 file.containerClass = 'no-background';
                 $previewer.previewer(file);
             } else {
+                loadingBar.start();
                 qtiItemPreviewerFactory($previewer, {itemUri:  $('#edit-media').data('uri')})
                     .on('error', function (err) {
                         if (!_.isUndefined(err.message)) {
                             feedback().error(err.message);
                         }
                         logger.error(err);
-                    });
+                    })
+                    .on('preview-loaded', loadingBar.stop);
             }
 
             if (file.mime !== 'application/qti+xml') {

--- a/views/js/previewer/component/qtiSharedStimulusItem.js
+++ b/views/js/previewer/component/qtiSharedStimulusItem.js
@@ -74,10 +74,13 @@ define([
         //extra context config
         testRunnerConfig.loadFromBundle = !!context.bundle;
 
-        return previewerFactory(container, testRunnerConfig, template).on('ready', runner => {
-            if (config.itemState) {
-                runner.on('renderitem', () => runner.itemRunner.setState(config.itemState));
-            }
+        return previewerFactory(container, testRunnerConfig, template).on('ready', function(runner) {
+            runner.on('renderitem', () => {
+                if (config.itemState) {
+                    runner.itemRunner.setState(config.itemState);
+                }
+                this.trigger('preview-loaded');
+            });
             if (config.itemUri) {
                 return runner.loadItem(config.itemUri);
             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-738

Added passage custom styles to dummy itemData in `getItem` function of `proxy/qtiSharedStimulusItem`

How to test:
- create new passage
- add custom styles
- save and go to Assets page
- refresh page and see passage preview
![image](https://user-images.githubusercontent.com/25976342/127109813-62bda172-fe14-49a1-b35a-e6354f1c0a9e.png)
