### PR TITLE
feat/AUT-34/ xincludeRendererAddStyles can be used in iframe

### DIFF
--- a/views/js/richPassage/xincludeRendererAddStyles.js
+++ b/views/js/richPassage/xincludeRendererAddStyles.js
@@ -18,8 +18,7 @@
 define(['jquery', 'uri', 'util/url', 'core/dataProvider/request'], function ($, uri, urlUtil, request) {
     'use strict';
 
-    return function xincludeRendererAddStyles(xinclude) {
-        const passageHref = xinclude.attr('href');
+    return function xincludeRendererAddStyles(passageHref, head = $('head')) {
         if (/taomedia:\/\/mediamanager\//.test(passageHref)) {
             // check rich passage styles and inject them to item
             const passageUri = uri.decode(passageHref.replace('taomedia://mediamanager/', ''));
@@ -36,7 +35,7 @@ define(['jquery', 'uri', 'util/url', 'core/dataProvider/request'], function ($, 
                                 stylesheet: element
                             })
                         });
-                        $('head').append(styleElem);
+                        head.append(styleElem);
                     });
                 })
                 .catch();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-34

Update `xincludeRendererAddStyles`, now it can be used in iframe

How to test:

- create rich passage
- go to item Authoring
- try add passage in items, check preview in resource manager
![image](https://user-images.githubusercontent.com/25976342/128025640-0108338c-6f45-4521-b727-a29d22d3afad.png)

Need to run `php ./tao/scripts/taoUpdate.php`