### PR TITLE
Backport/ADF-573/atomic roles improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 			"oat-sa/oatbox-extension-installer": "~1.1||dev-master",
 			"oat-sa/lib-generis-search": "2.1.2",
 			"oat-sa/generis" : ">=14.0.0",
-			"oat-sa/tao-core" : ">=48.20.0",
+			"oat-sa/tao-core" : ">=48.27.0",
 			"oat-sa/extension-tao-item" : ">=11.10.0",
 			"oat-sa/extension-tao-itemqti" : ">=28.8.0",
 			"oat-sa/extension-tao-test" : ">=15.0.0",

--- a/manifest.php
+++ b/manifest.php
@@ -65,6 +65,11 @@ return [
         ],
         [
             AccessRule::GRANT,
+            TaoAssetRoles::ASSET_CLASS_NAVIGATOR,
+            ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'files'],
+        ],
+        [
+            AccessRule::GRANT,
             TaoAssetRoles::ASSET_VIEWER,
             ['ext' => 'taoMediaManager', 'mod' => 'MediaManager', 'act' => 'editInstance']
         ],

--- a/manifest.php
+++ b/manifest.php
@@ -95,6 +95,11 @@ return [
         ],
         [
             AccessRule::GRANT,
+            TaoAssetRoles::ASSET_EXPORTER,
+            ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'download'],
+        ],
+        [
+            AccessRule::GRANT,
             TaoAssetRoles::ASSET_CONTENT_CREATOR,
             ['ext' => 'taoMediaManager', 'mod' => 'MediaManager', 'act' => 'authoring']
         ],

--- a/migrations/Version202108091845541888_taoMediaManager.php
+++ b/migrations/Version202108091845541888_taoMediaManager.php
@@ -32,6 +32,11 @@ use taoItems_actions_ItemContent;
 final class Version202108091845541888_taoMediaManager extends AbstractMigration
 {
     private const CONFIG = [
+        SetRolesAccess::CONFIG_RULES => [
+            TaoAssetRoles::ASSET_CLASS_NAVIGATOR => [
+                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'files'],
+            ],
+        ],
         SetRolesAccess::CONFIG_PERMISSIONS => [
             taoItems_actions_ItemContent::class => [
                 'previewAsset' => [

--- a/migrations/Version202108091845541888_taoMediaManager.php
+++ b/migrations/Version202108091845541888_taoMediaManager.php
@@ -24,11 +24,11 @@ namespace oat\taoMediaManager\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use oat\tao\scripts\update\OntologyUpdater;
-use oat\taoMediaManager\controller\MediaManager;
 use oat\taoMediaManager\model\user\TaoAssetRoles;
 use oat\tao\model\accessControl\ActionAccessControl;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 use oat\tao\scripts\tools\accessControl\SetRolesAccess;
+use taoItems_actions_ItemContent;
 
 final class Version202108091845541888_taoMediaManager extends AbstractMigration
 {
@@ -43,8 +43,8 @@ final class Version202108091845541888_taoMediaManager extends AbstractMigration
             ],
         ],
         SetRolesAccess::CONFIG_PERMISSIONS => [
-            MediaManager::class => [
-                'isDownloadEnabled' => [
+            taoItems_actions_ItemContent::class => [
+                'download' => [
                     TaoAssetRoles::ASSET_VIEWER => ActionAccessControl::DENY,
                     TaoAssetRoles::ASSET_EXPORTER => ActionAccessControl::READ,
                 ],

--- a/migrations/Version202108091845541888_taoMediaManager.php
+++ b/migrations/Version202108091845541888_taoMediaManager.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 namespace oat\taoMediaManager\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use oat\tao\scripts\update\OntologyUpdater;
 use oat\taoMediaManager\model\user\TaoAssetRoles;
 use oat\tao\model\accessControl\ActionAccessControl;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
@@ -33,20 +32,23 @@ use taoItems_actions_ItemContent;
 final class Version202108091845541888_taoMediaManager extends AbstractMigration
 {
     private const CONFIG = [
-        SetRolesAccess::CONFIG_RULES => [
-            TaoAssetRoles::ASSET_EXPORTER => [
-                [
-                    'ext' => 'taoItems',
-                    'mod' => 'ItemContent',
-                    'act' => 'download'
-                ],
-            ],
-        ],
         SetRolesAccess::CONFIG_PERMISSIONS => [
             taoItems_actions_ItemContent::class => [
-                'download' => [
-                    TaoAssetRoles::ASSET_VIEWER => ActionAccessControl::DENY,
+                'previewAsset' => [
+                    TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                    TaoAssetRoles::ASSET_PREVIEWER => ActionAccessControl::READ,
+                ],
+                'downloadAsset' => [
+                    TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                     TaoAssetRoles::ASSET_EXPORTER => ActionAccessControl::READ,
+                ],
+                'uploadAsset' => [
+                    TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                    TaoAssetRoles::ASSET_IMPORTER => ActionAccessControl::WRITE,
+                ],
+                'deleteAsset' => [
+                    TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                    TaoAssetRoles::ASSET_DELETER => ActionAccessControl::WRITE,
                 ],
             ],
         ],
@@ -54,13 +56,11 @@ final class Version202108091845541888_taoMediaManager extends AbstractMigration
 
     public function getDescription(): string
     {
-        return 'Give proper permission for delete and download assets';
+        return 'Give proper permission for delete, upload and download assets';
     }
 
     public function up(Schema $schema): void
     {
-        OntologyUpdater::syncModels();
-
         $setRolesAccess = $this->propagate(new SetRolesAccess());
         $setRolesAccess(
             [

--- a/migrations/Version202108091845541888_taoMediaManager.php
+++ b/migrations/Version202108091845541888_taoMediaManager.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoMediaManager\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\taoMediaManager\controller\MediaManager;
+use oat\taoMediaManager\model\user\TaoAssetRoles;
+use oat\tao\model\accessControl\ActionAccessControl;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\tools\accessControl\SetRolesAccess;
+
+final class Version202108091845541888_taoMediaManager extends AbstractMigration
+{
+    private const CONFIG = [
+        SetRolesAccess::CONFIG_RULES => [
+            TaoAssetRoles::ASSET_EXPORTER => [
+                [
+                    'ext' => 'taoItems',
+                    'mod' => 'ItemContent',
+                    'act' => 'download'
+                ],
+            ],
+        ],
+        SetRolesAccess::CONFIG_PERMISSIONS => [
+            MediaManager::class => [
+                'isDownloadEnabled' => [
+                    TaoAssetRoles::ASSET_VIEWER => ActionAccessControl::DENY,
+                    TaoAssetRoles::ASSET_EXPORTER => ActionAccessControl::READ,
+                ],
+            ],
+        ],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Give proper permission for delete and download assets';
+    }
+
+    public function up(Schema $schema): void
+    {
+        OntologyUpdater::syncModels();
+
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess(
+            [
+                '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+            ]
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess(
+            [
+                '--' . SetRolesAccess::OPTION_REVOKE,
+                '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+            ]
+        );
+    }
+}

--- a/model/mapper/MediaSourcePermissionsMapper.php
+++ b/model/mapper/MediaSourcePermissionsMapper.php
@@ -29,6 +29,7 @@ use oat\tao\model\media\mapper\MediaBrowserPermissionsMapper;
 
 class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
 {
+    private const PERMISSION_PREVIEW = 'PREVIEW';
     private const PERMISSION_DOWNLOAD = 'DOWNLOAD';
     private const PERMISSION_UPLOAD = 'UPLOAD';
     private const PERMISSION_DELETE = 'DELETE';
@@ -41,21 +42,28 @@ class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
         $data = parent::map($data, $resourceUri);
 
         if (
-            $this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'download')
+            $this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'previewAsset')
+            && $this->hasReadAccess($resourceUri)
+        ) {
+            $data[self::DATA_PERMISSIONS][] = self::PERMISSION_PREVIEW;
+        }
+
+        if (
+            $this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'downloadAsset')
             && $this->hasReadAccess($resourceUri)
         ) {
             $data[self::DATA_PERMISSIONS][] = self::PERMISSION_DOWNLOAD;
         }
 
         if (
-            $this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'delete')
+            $this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'deleteAsset')
             && $this->hasWriteAccess($resourceUri)
         ) {
             $data[self::DATA_PERMISSIONS][] = self::PERMISSION_DELETE;
         }
 
         if (
-            $this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'upload')
+            $this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'uploadAsset')
             && $this->hasWriteAccess($resourceUri)
         ) {
             $data[self::DATA_PERMISSIONS][] = self::PERMISSION_UPLOAD;
@@ -77,11 +85,11 @@ class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
     {
         $canDelete = $this->getActionAccessControl()->hasWriteAccess(
             taoItems_actions_ItemContent::class,
-            'delete'
+            'deleteAsset'
         );
         $canUpload = $this->getActionAccessControl()->hasWriteAccess(
             taoItems_actions_ItemContent::class,
-            'upload'
+            'uploadAsset'
         );
 
         return parent::hasWriteAccess($uri) && ($canDelete || $canUpload);

--- a/model/mapper/MediaSourcePermissionsMapper.php
+++ b/model/mapper/MediaSourcePermissionsMapper.php
@@ -23,13 +23,16 @@ declare(strict_types=1);
 namespace oat\taoMediaManager\model\mapper;
 
 use oat\tao\model\accessControl\Context;
-use oat\taoMediaManager\controller\MediaManager;
 use taoItems_actions_ItemContent;
 use oat\tao\model\accessControl\ActionAccessControl;
 use oat\tao\model\media\mapper\MediaBrowserPermissionsMapper;
 
 class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
 {
+    private const PERMISSION_DOWNLOAD = 'DOWNLOAD';
+    private const PERMISSION_UPLOAD = 'UPLOAD';
+    private const PERMISSION_DELETE = 'DELETE';
+
     /** @var ActionAccessControl */
     private $actionAccessControl;
 
@@ -37,16 +40,19 @@ class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
     {
         $data = parent::map($data, $resourceUri);
 
-        if ($this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'isDownloadEnabled')) {
-            $data['permissions'][] = 'DOWNLOAD';
+        if ($this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'download')
+            && $this->hasReadAccess($resourceUri)) {
+            $data[parent::DATA_PERMISSIONS][] = self::PERMISSION_DOWNLOAD;
         }
 
-        if ($this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'delete')) {
-            $data['permissions'][] = 'DELETE';
+        if ($this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'delete')
+            && $this->hasWriteAccess($resourceUri)) {
+            $data[parent::DATA_PERMISSIONS][] = self::PERMISSION_DELETE;
         }
 
-        if ($this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'upload')) {
-            $data['permissions'][] = 'UPLOAD';
+        if ($this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'upload')
+            && $this->hasWriteAccess($resourceUri)) {
+            $data[parent::DATA_PERMISSIONS][] = self::PERMISSION_UPLOAD;
         }
 
         return $data;

--- a/model/mapper/MediaSourcePermissionsMapper.php
+++ b/model/mapper/MediaSourcePermissionsMapper.php
@@ -40,19 +40,25 @@ class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
     {
         $data = parent::map($data, $resourceUri);
 
-        if ($this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'download')
-            && $this->hasReadAccess($resourceUri)) {
-            $data[parent::DATA_PERMISSIONS][] = self::PERMISSION_DOWNLOAD;
+        if (
+            $this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'download')
+            && $this->hasReadAccess($resourceUri)
+        ) {
+            $data[self::DATA_PERMISSIONS][] = self::PERMISSION_DOWNLOAD;
         }
 
-        if ($this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'delete')
-            && $this->hasWriteAccess($resourceUri)) {
-            $data[parent::DATA_PERMISSIONS][] = self::PERMISSION_DELETE;
+        if (
+            $this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'delete')
+            && $this->hasWriteAccess($resourceUri)
+        ) {
+            $data[self::DATA_PERMISSIONS][] = self::PERMISSION_DELETE;
         }
 
-        if ($this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'upload')
-            && $this->hasWriteAccess($resourceUri)) {
-            $data[parent::DATA_PERMISSIONS][] = self::PERMISSION_UPLOAD;
+        if (
+            $this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'upload')
+            && $this->hasWriteAccess($resourceUri)
+        ) {
+            $data[self::DATA_PERMISSIONS][] = self::PERMISSION_UPLOAD;
         }
 
         return $data;
@@ -67,9 +73,6 @@ class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
             );
     }
 
-    /*
-     *  TODO split permissions to upload and delete assets
-     */
     protected function hasWriteAccess(string $uri): bool
     {
         $canDelete = $this->getActionAccessControl()->hasWriteAccess(

--- a/model/mapper/MediaSourcePermissionsMapper.php
+++ b/model/mapper/MediaSourcePermissionsMapper.php
@@ -72,15 +72,6 @@ class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
         return $data;
     }
 
-    protected function hasReadAccess(string $uri): bool
-    {
-        return parent::hasReadAccess($uri)
-            && $this->getActionAccessControl()->hasReadAccess(
-                taoItems_actions_ItemContent::class,
-                'files'
-            );
-    }
-
     protected function hasWriteAccess(string $uri): bool
     {
         $canDelete = $this->getActionAccessControl()->hasWriteAccess(

--- a/scripts/install/SetRolesPermissions.php
+++ b/scripts/install/SetRolesPermissions.php
@@ -60,6 +60,10 @@ class SetRolesPermissions extends InstallAction
                     TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                     TaoAssetRoles::ASSET_RESOURCE_CREATOR => ActionAccessControl::WRITE,
                 ],
+                'download' => [
+                    TaoAssetRoles::ASSET_VIEWER => ActionAccessControl::DENY,
+                    TaoAssetRoles::ASSET_EXPORTER => ActionAccessControl::READ,
+                ],
             ],
             MediaImport::class => [
                 'editMedia' => [

--- a/scripts/install/SetRolesPermissions.php
+++ b/scripts/install/SetRolesPermissions.php
@@ -60,9 +60,21 @@ class SetRolesPermissions extends InstallAction
                     TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                     TaoAssetRoles::ASSET_RESOURCE_CREATOR => ActionAccessControl::WRITE,
                 ],
-                'download' => [
-                    TaoAssetRoles::ASSET_VIEWER => ActionAccessControl::DENY,
+                'previewAsset' => [
+                    TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                    TaoAssetRoles::ASSET_PREVIEWER => ActionAccessControl::READ,
+                ],
+                'downloadAsset' => [
+                    TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                     TaoAssetRoles::ASSET_EXPORTER => ActionAccessControl::READ,
+                ],
+                'uploadAsset' => [
+                    TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                    TaoAssetRoles::ASSET_IMPORTER => ActionAccessControl::WRITE,
+                ],
+                'deleteAsset' => [
+                    TaoAssetRoles::ASSET_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                    TaoAssetRoles::ASSET_DELETER => ActionAccessControl::WRITE,
                 ],
             ],
             MediaImport::class => [

--- a/test/unit/model/mapper/MediaSourcePermissionsMapperTest.php
+++ b/test/unit/model/mapper/MediaSourcePermissionsMapperTest.php
@@ -80,6 +80,7 @@ class MediaSourcePermissionsMapperTest extends TestCase
                 'permissions' => [
                     'READ',
                     'WRITE',
+                    'PREVIEW',
                     'DOWNLOAD',
                     'DELETE',
                     'UPLOAD',

--- a/test/unit/model/mapper/MediaSourcePermissionsMapperTest.php
+++ b/test/unit/model/mapper/MediaSourcePermissionsMapperTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoMediaManager\test\unit\model\mapper;
+
+use JsonSerializable;
+use oat\generis\test\TestCase;
+use oat\tao\model\accessControl\ActionAccessControl;
+use oat\tao\model\accessControl\PermissionChecker;
+use oat\taoMediaManager\model\mapper\MediaSourcePermissionsMapper;
+use oat\taoMediaManager\model\relation\MediaRelation;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class MediaSourcePermissionsMapperTest extends TestCase
+{
+    /** @var ActionAccessControl|MockObject */
+    private $actionAccessControl;
+
+    /** @var MediaSourcePermissionsMapper */
+    private $subject;
+
+    /** @var PermissionChecker|MockObject */
+    private $permissionChecker;
+
+    public function setUp(): void
+    {
+        $this->actionAccessControl = $this->createMock(ActionAccessControl::class);
+        $this->permissionChecker = $this->createMock(PermissionChecker::class);
+        $this->subject = new MediaSourcePermissionsMapper();
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    ActionAccessControl::SERVICE_ID => $this->actionAccessControl,
+                    PermissionChecker::class => $this->permissionChecker,
+                ]
+            )
+        );
+    }
+
+    public function testMap(): void
+    {
+        $data = [];
+        $resourceUri = 'resourceUri';
+
+        $this->actionAccessControl
+            ->method('contextHasReadAccess')
+            ->willReturn(true);
+
+        $this->actionAccessControl
+            ->method('hasReadAccess')
+            ->willReturn(true);
+
+        $this->actionAccessControl
+            ->method('contextHasWriteAccess')
+            ->willReturn(true);
+
+        $this->actionAccessControl
+            ->method('hasWriteAccess')
+            ->willReturn(true);
+
+        $this->assertEquals(
+            [
+                'permissions' => [
+                    'READ',
+                    'WRITE',
+                    'DOWNLOAD',
+                    'DELETE',
+                    'UPLOAD',
+                ]
+            ],
+            $this->subject->map($data, $resourceUri)
+        );
+    }
+}

--- a/test/unit/model/mapper/MediaSourcePermissionsMapperTest.php
+++ b/test/unit/model/mapper/MediaSourcePermissionsMapperTest.php
@@ -22,12 +22,10 @@ declare(strict_types=1);
 
 namespace oat\taoMediaManager\test\unit\model\mapper;
 
-use JsonSerializable;
 use oat\generis\test\TestCase;
 use oat\tao\model\accessControl\ActionAccessControl;
 use oat\tao\model\accessControl\PermissionChecker;
 use oat\taoMediaManager\model\mapper\MediaSourcePermissionsMapper;
-use oat\taoMediaManager\model\relation\MediaRelation;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class MediaSourcePermissionsMapperTest extends TestCase
@@ -56,7 +54,7 @@ class MediaSourcePermissionsMapperTest extends TestCase
         );
     }
 
-    public function testMap(): void
+    public function testMapWithAllPermissions(): void
     {
         $data = [];
         $resourceUri = 'resourceUri';
@@ -85,6 +83,38 @@ class MediaSourcePermissionsMapperTest extends TestCase
                     'DOWNLOAD',
                     'DELETE',
                     'UPLOAD',
+                ]
+            ],
+            $this->subject->map($data, $resourceUri)
+        );
+    }
+
+    public function testMapWithOnlyReadAndWritePermissions(): void
+    {
+        $data = [];
+        $resourceUri = 'resourceUri';
+
+        $this->actionAccessControl
+            ->method('contextHasReadAccess')
+            ->willReturn(false);
+
+        $this->actionAccessControl
+            ->method('hasReadAccess')
+            ->willReturn(true);
+
+        $this->actionAccessControl
+            ->method('contextHasWriteAccess')
+            ->willReturn(false);
+
+        $this->actionAccessControl
+            ->method('hasWriteAccess')
+            ->willReturn(true);
+
+        $this->assertEquals(
+            [
+                'permissions' => [
+                    'READ',
+                    'WRITE',
                 ]
             ],
             $this->subject->map($data, $resourceUri)

--- a/views/cypress/tests/assets.spec.js
+++ b/views/cypress/tests/assets.spec.js
@@ -1,0 +1,90 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+import urls from '../utils/urls';
+import selectors from '../utils/selectors';
+
+describe('Assets', () => {
+    const className = 'Asset E2E class';
+    const classMovedName = 'Asset E2E class Moved';
+
+    /**
+     * Log in and wait for render
+     * After @treeRender click root class
+     */
+    before(() => {
+        cy.loginAsAdmin();
+        cy.intercept('GET', `**/${ selectors.treeRenderUrl }/getOntologyData**`).as('treeRender');
+        cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel');
+        cy.visit(urls.assets);
+        cy.wait('@treeRender', { requestTimeout: 10000 });
+        cy.get(`${selectors.root} a`)
+            .first()
+            .click();
+        cy.wait('@editClassLabel', { requestTimeout: 10000 });
+    });
+
+    /**
+     * Assets
+     */
+    describe('Asset creation, editing and deletion', () => {
+        it('can create a new asset class', function () {
+            cy.addClassToRoot(
+                selectors.root,
+                selectors.assetClassForm,
+                className,
+                selectors.editClassLabelUrl,
+                selectors.treeRenderUrl,
+                selectors.addSubClassUrl
+            );
+        });
+
+        it('can move asset class', function () {
+            cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel');
+
+            cy.getSettled(`${selectors.root} a:nth(0)`)
+            .click()
+            .wait('@editClassLabel', { requestTimeout: 10000 })
+            .addClass(selectors.assetClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
+            .renameSelectedClass(selectors.assetClassForm, classMovedName);
+
+            cy.wait('@treeRender', { requestTimeout: 10000 });
+
+            cy.moveClassFromRoot(
+                selectors.root,
+                selectors.moveClass,
+                selectors.moveConfirmSelector,
+                className,
+                classMovedName,
+                selectors.restResourceGetAll
+            );
+        });
+
+        it('can delete asset class', function () {
+            cy.deleteClassFromRoot(
+                selectors.root,
+                selectors.assetClassForm,
+                selectors.deleteClass,
+                selectors.deleteConfirm,
+                classMovedName,
+                selectors.deleteClassUrl,
+                false
+            );
+        });
+    });
+});

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -1,0 +1,16 @@
+export default {
+    deleteClass: '[data-context="class"][data-action="deleteSharedStimulus"]',
+    moveClass: '[id="media-move-to"][data-context="resource"][data-action="moveTo"]',
+    moveConfirmSelector: 'button[data-control="ok"]',
+    assetForm: 'form[action="/taoMediaManager/MediaManager/editInstance"]',
+    assetClassForm: 'form[action="/taoMediaManager/MediaManager/editClassLabel"]',
+    deleteConfirm: 'button[data-control="ok"]',
+    root: '[data-uri="http://www.tao.lu/Ontologies/TAOMedia.rdf#Media"]',
+    editClassLabelUrl: 'taoMediaManager/MediaManager/editClassLabel',
+    editItemUrl: 'taoMediaManager/MediaManager/editItem',
+    treeRenderUrl: 'taoMediaManager/MediaManager',
+    addSubClassUrl: 'taoMediaManager/MediaManager/addSubClass',
+    restResourceGetAll: 'tao/RestResource/getAll',
+    resourceRelations: 'tao/ResourceRelations',
+    deleteClassUrl: 'taoMediaManager/MediaManager/deleteClass',
+};


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-573

commit 1efb5ab273a7bb4e596f4d7cd00e5b74cdd41a17
Author: Cristian Lagos <17564918+clagosarias@users.noreply.github.com>
Date:   Thu Aug 19 18:19:25 2021 +0200

    chore: update composer

commit 3a0ea754c1abf2588b76c1031ea38bd6f596c90f
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Thu Aug 12 16:23:24 2021 +0200

    Merge branch 'develop' of https://github.com/oat-sa/extension-tao-mediamanager into feature/ADF-573/atomic-roles-improvements

commit 54b1e9a46643b9d0c214940d3399e38579f85767
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Wed Aug 11 15:48:34 2021 +0200

    fix: missing permission to list assets

commit 203ab7d9d8fd8362aaecd25073745f65d6e63623
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Wed Aug 11 10:08:32 2021 +0200

    chore: add key permissions on installation

commit 0cbc82b1eb04d2095fae9b098165096a2b4073cf
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Tue Aug 10 17:06:14 2021 +0200

    feat: adjust permissions

commit cd3492e6e0145e34f5985421db43ecfff1d84cc6
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Tue Aug 10 08:13:38 2021 +0200

    refact: improve unit tests

commit c696e9e7138a93a3a982fb8de5784a67a2575cd2
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Mon Aug 9 17:37:24 2021 +0200

    feat: add unit tests

commit aea4470f51b99f9b6ccd892a9ac2e6cfd7158243
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Mon Aug 9 16:26:14 2021 +0200

    feat: installation script for new permission and better permission check

commit 96e501a54dbb13411bc1a383d2583468bd38c64a
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Mon Aug 9 13:52:43 2021 +0200

    feat: add permissions for upload and delete separately