### PR TITLE
Fix/ADF-627/Reconfigure Asset Content Creator role permissions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
 			"oat-sa/oatbox-extension-installer": "~1.1||dev-master",
 			"oat-sa/lib-generis-search": "2.1.2",
 			"oat-sa/generis" : ">=14.0.0",
-			"oat-sa/tao-core" : ">=48.27.0",
-			"oat-sa/extension-tao-item" : ">=11.10.0",
+			"oat-sa/tao-core" : ">=48.31.2",
+			"oat-sa/extension-tao-item" : ">=11.13.4",
 			"oat-sa/extension-tao-itemqti" : ">=28.8.0",
 			"oat-sa/extension-tao-test" : ">=15.0.0",
 			"oat-sa/extension-tao-testqti-previewer" : "*"

--- a/model/classes/user/TaoAssetRoles.php
+++ b/model/classes/user/TaoAssetRoles.php
@@ -22,16 +22,11 @@ declare(strict_types=1);
 
 namespace oat\taoMediaManager\model\classes\user;
 
+use oat\taoMediaManager\model\user\TaoAssetRoles as BaseTaoAssetRoles;
+
 /**
  * @deprecated Use \oat\taoMediaManager\model\user\TaoAssetRoles
  */
-interface TaoAssetRoles
+interface TaoAssetRoles extends BaseTaoAssetRoles
 {
-    public const MEDIA_MANAGER = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#MediaManagerRole';
-    public const ASSET_CLASS_NAVIGATOR = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#AssetClassNavigatorRole';
-    public const ASSET_VIEWER = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#AssetViewerRole';
-    public const ASSET_EXPORTER = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#AssetExporterRole';
-    public const ASSET_PREVIEWER = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#AssetPreviewerRole';
-    public const ASSET_PROPERTIES_EDITOR = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#AssetPropertiesEditorRole';
-    public const ASSET_CONTENT_CREATOR = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#AssetContentCreatorRole';
 }

--- a/model/classes/user/TaoAssetRoles.php
+++ b/model/classes/user/TaoAssetRoles.php
@@ -22,6 +22,9 @@ declare(strict_types=1);
 
 namespace oat\taoMediaManager\model\classes\user;
 
+/**
+ * @deprecated Use \oat\taoMediaManager\model\user\TaoAssetRoles
+ */
 interface TaoAssetRoles
 {
     public const MEDIA_MANAGER = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#MediaManagerRole';

--- a/model/mapper/MediaSourcePermissionsMapper.php
+++ b/model/mapper/MediaSourcePermissionsMapper.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace oat\taoMediaManager\model\mapper;
 
-use oat\tao\model\accessControl\Context;
 use taoItems_actions_ItemContent;
+use oat\tao\model\accessControl\Context;
 use oat\tao\model\accessControl\ActionAccessControl;
 use oat\tao\model\media\mapper\MediaBrowserPermissionsMapper;
 
@@ -72,13 +72,19 @@ class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
         return $data;
     }
 
+    protected function hasReadAccess(string $uri): bool
+    {
+        return parent::hasReadAccess($uri)
+            && $this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'viewAsset');
+    }
+
     protected function hasWriteAccess(string $uri): bool
     {
-        $canDelete = $this->getActionAccessControl()->hasWriteAccess(
+        $canDelete = $this->hasWriteAccessByContext(
             taoItems_actions_ItemContent::class,
             'deleteAsset'
         );
-        $canUpload = $this->getActionAccessControl()->hasWriteAccess(
+        $canUpload = $this->hasWriteAccessByContext(
             taoItems_actions_ItemContent::class,
             'uploadAsset'
         );
@@ -98,24 +104,20 @@ class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
     private function hasReadAccessByContext(string $controller, string $action): bool
     {
         return $this->getActionAccessControl()->contextHasReadAccess(
-            new Context(
-                [
-                    Context::PARAM_CONTROLLER => $controller,
-                    Context::PARAM_ACTION => $action,
-                ]
-            )
+            new Context([
+                Context::PARAM_CONTROLLER => $controller,
+                Context::PARAM_ACTION => $action,
+            ])
         );
     }
 
     private function hasWriteAccessByContext(string $controller, string $action): bool
     {
         return $this->getActionAccessControl()->contextHasWriteAccess(
-            new Context(
-                [
-                    Context::PARAM_CONTROLLER => $controller,
-                    Context::PARAM_ACTION => $action,
-                ]
-            )
+            new Context([
+                Context::PARAM_CONTROLLER => $controller,
+                Context::PARAM_ACTION => $action,
+            ])
         );
     }
 }

--- a/model/mapper/MediaSourcePermissionsMapper.php
+++ b/model/mapper/MediaSourcePermissionsMapper.php
@@ -40,31 +40,34 @@ class MediaSourcePermissionsMapper extends MediaBrowserPermissionsMapper
     public function map(array $data, string $resourceUri): array
     {
         $data = parent::map($data, $resourceUri);
+        $hasReadAccess = $this->hasReadAccess($resourceUri);
 
         if (
             $this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'previewAsset')
-            && $this->hasReadAccess($resourceUri)
+            && $hasReadAccess
         ) {
             $data[self::DATA_PERMISSIONS][] = self::PERMISSION_PREVIEW;
         }
 
         if (
             $this->hasReadAccessByContext(taoItems_actions_ItemContent::class, 'downloadAsset')
-            && $this->hasReadAccess($resourceUri)
+            && $hasReadAccess
         ) {
             $data[self::DATA_PERMISSIONS][] = self::PERMISSION_DOWNLOAD;
         }
 
+        $hasWriteAccess = $this->hasWriteAccess($resourceUri);
+
         if (
             $this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'deleteAsset')
-            && $this->hasWriteAccess($resourceUri)
+            && $hasWriteAccess
         ) {
             $data[self::DATA_PERMISSIONS][] = self::PERMISSION_DELETE;
         }
 
         if (
             $this->hasWriteAccessByContext(taoItems_actions_ItemContent::class, 'uploadAsset')
-            && $this->hasWriteAccess($resourceUri)
+            && $hasWriteAccess
         ) {
             $data[self::DATA_PERMISSIONS][] = self::PERMISSION_UPLOAD;
         }

--- a/test/unit/model/mapper/MediaSourcePermissionsMapperTest.php
+++ b/test/unit/model/mapper/MediaSourcePermissionsMapperTest.php
@@ -84,7 +84,7 @@ class MediaSourcePermissionsMapperTest extends TestCase
                     'DOWNLOAD',
                     'DELETE',
                     'UPLOAD',
-                ]
+                ],
             ],
             $this->subject->map($data, $resourceUri)
         );
@@ -113,10 +113,7 @@ class MediaSourcePermissionsMapperTest extends TestCase
 
         $this->assertEquals(
             [
-                'permissions' => [
-                    'READ',
-                    'WRITE',
-                ]
+                'permissions' => [],
             ],
             $this->subject->map($data, $resourceUri)
         );


### PR DESCRIPTION
**Relates to:** _[ADF-627](https://oat-sa.atlassian.net/browse/ADF-627)_

---

**Changes:**
* `files`, `upload` and `delete` permissions revoked;
* `viewAsset` permission added;
* Check for `viewAsset` read access during permissions mapper.

---

**Companion PRs:**
* https://github.com/oat-sa/extension-tao-item/pull/512
* https://github.com/oat-sa/tao-core/pull/3085