### PR TITLE
fix/AUT-963/ e2e move treeRender in commands

### DIFF
--- a/views/cypress/tests/assets.spec.js
+++ b/views/cypress/tests/assets.spec.js
@@ -63,8 +63,6 @@ describe('Assets', () => {
             .addClass(selectors.assetClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
             .renameSelectedClass(selectors.assetClassForm, classMovedName);
 
-            cy.wait('@treeRender');
-
             cy.moveClassFromRoot(
                 selectors.root,
                 selectors.moveClass,


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-963
Dependency:

- [x] https://github.com/oat-sa/tao-core/pull/3124

Move wait.("@treeRender") to commands

How to test:
run test `taoMediaManager/views/cypress/tests/assets.spec.js`
