### PR TITLE
fix: interaction panel in rich passage

### DIFF
--- a/views/js/qtiCreator/editor/interactionsPanel.js
+++ b/views/js/qtiCreator/editor/interactionsPanel.js
@@ -47,7 +47,8 @@ define([
                 ),
                 short: __('Block'),
                 qtiClass: '_container',
-                tags: [tagTitles.inlineInteractions, 'text']
+                tags: [tagTitles.inlineInteractions, 'text'],
+                group:  __('inline-interactions')
             }
         };
 


### PR DESCRIPTION
Related to Issue: https://oat-sa.atlassian.net/browse/AUT-773
Related to PR:  https://github.com/oat-sa/extension-tao-itemqti/pull/1899

id attributes get translated. Check that rich passage (Media manager) interaction panel works as expected.

SETPS to test:
• Checkout to branch: fix/AUT-773/id-attributes-get-translated
•Create a rich passage
•Interaction panel on the left should contain an inline text interaction as expected.
• Inspect elements in the dev tools: Group id shouldn't change independently of the language

ENV to test: http://test-silvia.playground.kitchen.it.taocloud.org:41441