### PR TITLE
feature: [e2e testing] add open passage authoring tests

### DIFF
--- a/views/cypress/tests/assets.spec.js
+++ b/views/cypress/tests/assets.spec.js
@@ -22,6 +22,7 @@ import selectors from '../utils/selectors';
 describe('Assets', () => {
     const className = 'Asset E2E class';
     const classMovedName = 'Asset E2E class Moved';
+    const AssetRenamed = 'Renamed E2E Asset';
 
     /**
      * Log in and wait for render
@@ -39,7 +40,7 @@ describe('Assets', () => {
     /**
      * Assets
      */
-    describe('Asset creation, editing and deletion', () => {
+    describe('Asset class creation and editing', () => {
         it('can create a new asset class', function () {
             cy.addClassToRoot(
                 selectors.root,
@@ -50,15 +51,42 @@ describe('Assets', () => {
                 selectors.addSubClassUrl
             );
         });
+    });
+    describe('Asset creating, authoring and deletion', () => {
+        it('can create and rename an Asset', function () {
+            cy.selectNode(selectors.root, selectors.assetClassForm, className)
+            .addNode(selectors.assetForm, selectors.addAsset)
+            .renameSelectedNode(selectors.assetForm, selectors.editAssetUrl,AssetRenamed );
+        });
+        it('can click passage Authoring & check all blocks present', function () {
+            cy.get(selectors.authoringAsset).click();
+            cy.get(selectors.assetAuthoringPanel).find('li[data-qti-class="_container"]');
+            cy.getSettled(selectors.assetAuthoringCanvas).should('have.length', 1);
+        });
+        it('can go back', function () {
+            cy.get(selectors.manageAssets).click();
+            cy.getSettled(selectors.treeMediaManager).find(`li[title="${AssetRenamed}"]`);
+        });
+        it('can delete passage', function () {
+            cy.get(`li[title="${AssetRenamed}"]`)
+            .deleteNode(
+                selectors.root,
+                selectors.deleteAsset,
+                selectors.editAssetUrl,
+                AssetRenamed
+            );
+        });
+    });
 
+    describe('Moving and deleting asset class', function () {
         it('can move asset class', function () {
             cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel');
 
             cy.getSettled(`${selectors.root} a:nth(0)`)
-            .click()
-            .wait('@editClassLabel')
-            .addClass(selectors.assetClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
-            .renameSelectedClass(selectors.assetClassForm, classMovedName);
+                .click()
+                .wait('@editClassLabel')
+                .addClass(selectors.assetClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
+                .renameSelectedClass(selectors.assetClassForm, classMovedName);
 
             cy.moveClassFromRoot(
                 selectors.root,

--- a/views/cypress/tests/assets.spec.js
+++ b/views/cypress/tests/assets.spec.js
@@ -56,7 +56,7 @@ describe('Assets', () => {
         it('can create and rename an Asset', function () {
             cy.selectNode(selectors.root, selectors.assetClassForm, className)
             .addNode(selectors.assetForm, selectors.addAsset)
-            .renameSelectedNode(selectors.assetForm, selectors.editAssetUrl,AssetRenamed );
+            .renameSelectedNode(selectors.assetForm, selectors.editAssetUrl, AssetRenamed );
         });
         it('can click passage Authoring & check all blocks present', function () {
             cy.get(selectors.authoringAsset).click();

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -1,12 +1,21 @@
 export default {
     addSubClassUrl: 'taoMediaManager/MediaManager/addSubClass',
     assetClassForm: 'form[action="/taoMediaManager/MediaManager/editClassLabel"]',
+    addAsset: '[data-context="resource"][data-action="newSharedStimulus"]',
+    assetForm: 'form[action="/taoMediaManager/MediaManager/editInstance"]',
+    authoringAsset: '[data-action= "sharedStimulusAuthoring"]',
+    assetAuthoringPanel: 'section[id="sidebar-left-section-inline-interactions"]',
+    assetAuthoringCanvas: 'div[id="item-editor-scroll-inner"]',
+    manageAssets: 'li[data-testid="manage-assets"]',
 
     deleteClass: '[data-context="class"][data-action="deleteSharedStimulus"]',
     deleteConfirm: 'button[data-control="ok"]',
     deleteClassUrl: 'taoMediaManager/MediaManager/deleteClass',
+    deleteAsset: '[data-context="instance"][data-action="deleteSharedStimulus"]',
+    deleteAssetUrl: 'taoMediaManager/MediaManager/deleteResource',
 
     editClassLabelUrl: 'taoMediaManager/MediaManager/editClassLabel',
+    editAssetUrl: 'taoMediaManager/MediaManager/editInstance',
 
     moveClass: '[id="media-move-to"][data-context="resource"][data-action="moveTo"]',
     moveConfirmSelector: 'button[data-control="ok"]',
@@ -15,4 +24,5 @@ export default {
     restResourceGetAll: 'tao/RestResource/getAll',
 
     treeRenderUrl: 'taoMediaManager/MediaManager',
+    treeMediaManager :'div[id="tree-media_manager"]'
 };


### PR DESCRIPTION
**End to end testing.**
Related to: https://oat-sa.atlassian.net/browse/AUT-1167

**Description of changes:**
Creation of E2E tests for passage authoring. Open passage authoring:
 Tests for:

-  Asset creation
-  Click authoring, 
-  Check all blocks present, 
-  Go back (check that asset present)
-  Delete asset

**How to run locally:**
Checkout to AUT-1167/e2e-testing-open-passage-authoring in extn taoMediaManager

run tests from tao core extn:
npm run cy:open - to run in browser
or npm run cy:run - for headless execution

**Expected result:** All tests pass successfully