### PR TITLE
fix: broken unit test

### DIFF
--- a/test/unit/model/sharedStimulus/service/StoreServiceTest.php
+++ b/test/unit/model/sharedStimulus/service/StoreServiceTest.php
@@ -58,7 +58,7 @@ class StoreServiceTest extends TestCase
             ->with($fakeUniqueName);
 
         $fileSystemMock->expects(self::once())
-            ->method('writeStream')
+            ->method('putStream')
             ->willReturn(true);
 
         $stimulusStoreService = $this->getPreparedServiceInstance($fileSystemMock);
@@ -78,7 +78,7 @@ class StoreServiceTest extends TestCase
     {
         return $this->getMockBuilder(FileSystem::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['createDir', 'writeStream'])
+            ->onlyMethods(['createDir', 'putStream'])
             ->getMock();
     }
 


### PR DESCRIPTION
Fixing broken unit test:

`StoreServiceTest::testStoreSharedStimulus`
Error: Call to a member function putStream() on null


https://oat-sa.atlassian.net/browse/AUT-1331