### PR TITLE
fix: define jquery when it is used

### DIFF
--- a/views/js/qtiCreator/editor/propertiesPanel.js
+++ b/views/js/qtiCreator/editor/propertiesPanel.js
@@ -18,13 +18,14 @@
  */
 
 define([
+    'jquery',
     'taoQtiItem/qtiCreator/helper/panel',
     'taoMediaManager/qtiCreator/editor/styleEditor/styleEditor',
     'taoMediaManager/qtiCreator/editor/styleEditor/styleSheetToggler',
     'taoMediaManager/qtiCreator/editor/styleEditor/fontSelector',
     'taoMediaManager/qtiCreator/editor/styleEditor/colorSelector',
     'taoMediaManager/qtiCreator/editor/styleEditor/fontSizeChanger'
-], function (panel, styleEditor, styleSheetToggler, fontSelector, colorSelector, fontSizeChanger) {
+], function ($, panel, styleEditor, styleSheetToggler, fontSelector, colorSelector, fontSizeChanger) {
     'use strict';
 
     /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1331

We need to define/import `jquery` in each file where `jquery` is used
In case it is not defined will be loaded `jquery` from `tao/views/js` not from bundles
