### PR TITLE
Fix/ADF-309/Do not remove classes due to restricted resources while deletion

### DIFF
--- a/views/js/controller/actions.js
+++ b/views/js/controller/actions.js
@@ -207,6 +207,11 @@ define([
                     uri: actionContext.uri || actionContext.classUri
                 });
             } else {
+                if (response.success && !response.deleted) {
+                    $(actionContext.tree).trigger('refresh.taotree');
+                    reject(response.msg || __('Unable to delete the selected resource because you do not have the required rights to delete part of its content.'));
+                }
+
                 reject(response.msg || __('Unable to delete the selected resource'));
             }
         });


### PR DESCRIPTION
# [ADF-309](https://oat-sa.atlassian.net/browse/ADF-309)

## Companion PRs:
* https://github.com/oat-sa/extension-tao-test/pull/409
* https://github.com/oat-sa/tao-core/pull/3233
* https://github.com/oat-sa/extension-tao-item/pull/548

## How to test (Example on `Items` section)
1. Create new user with `Item Author` role;
2. Open `Items` section;
3. Make the following structure
    <details>
    <summary>Expand</summary>

    ```
    Root Class
    |
    |____Class 1
    |      |
    |      |____Class 1_1
    |      |      |
    |      |      |____Class 1 - Item 1    <================
    |      |      |____Class 1 - Item 2
    |      |
    |      |____Class 1_2
    |      |      |
    |      |      |____Class 2 - Item 1
    |      |      |____Class 2 - Item 2
    |      |
    |      |____Class 1_3    <================
    |             |
    |             |____Class 3 - Item 1
    |             |____Class 3 - Item 2
    |
    |____Root Class - Item 1    <================
    |____Root Class - Item 2
    ```
    </details>
4. Open an access control for the marked by arrows elements and replace `Back Office` role with `Global Manager` (Grant);
5. Log in as recently created user;
6. Select `Class 1` and try to delete it.

**Old behavior:** _`Class 1` with all subclasses and instances (items) was deleted._
**New behavior:** _Only accessible subclasses and instances (items) were deleted. `Class 1` still present and contains all protected elements._

## Tasks
- [ ] Update `tao-core` dependency