### PR TITLE
Feature/aut 1195/e2e add asset passage to interaction

### DIFF
--- a/views/cypress/tests/add-asset-passage-to-interaction.spec.js
+++ b/views/cypress/tests/add-asset-passage-to-interaction.spec.js
@@ -125,6 +125,7 @@ describe('Passage Authoring', () => {
 
         it('can save passage with A block & content', () => {
              cy.intercept('PATCH', '**/taoMediaManager/SharedStimulus/patch*').as('savePassage');
+             cy.get(selectors.assetAuthoringSaveButton).should('not.be.disabled');
              cy.get(selectors.assetAuthoringSaveButton).click({ force: true });
              cy.wait('@savePassage').its('response.body').its('success').should('eq', true);
              cy.get(`${selectors.manageAssets}`).click();

--- a/views/cypress/tests/add-asset-passage-to-interaction.spec.js
+++ b/views/cypress/tests/add-asset-passage-to-interaction.spec.js
@@ -21,9 +21,9 @@ import urlsItem from '../../../../taoQtiItem/views/cypress/utils/urls'
 import selectors from '../utils/selectors';
 import selectorsItem from '../../../../taoQtiItem/views/cypress/utils/selectors';
 
-import { selectUploadAssetToClass } from '../utils/resource-manager';
-import {selectUploadSharedStimulus,
-        addSharedStimulusToInteraction } from "../../../../taoQtiItem/views/cypress/utils/resource-manager";
+import { selectUploadAssetToClass,
+         selectUploadSharedStimulusToItem} from '../utils/resource-manager';
+import { addSharedStimulusToInteraction } from "../../../../taoQtiItem/views/cypress/utils/resource-manager";
 import { addAblock } from '../../../../taoQtiItem/views/cypress/utils/authoring-add-interactions';
 import { addInteraction } from "../../../../taoQtiItem/views/cypress/utils/authoring-add-interactions";
 
@@ -37,6 +37,7 @@ const itemName = 'Test E2E passage 1';
 const choiceInteraction = 'choice';
 const ablockContainerParagraph = '.widget-box[data-qti-class="_container"] p';
 const aBlockContainer = '.widget-box[data-qti-class="_container"]';
+const dataAlt = 'passage NEW.xml';
 
 describe('Passage Authoring', () => {
     /**
@@ -169,15 +170,14 @@ describe('Passage Authoring', () => {
             const isCreatedAsset = true;
             const isChoice = false;
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulus(isCreatedAsset);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt);
         });
 
         it('can add created passage to the choice & save', function () {
             const isCreatedAsset = true;
             const isChoice = true;
-
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulus(isCreatedAsset);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt);
             cy.intercept('POST', '**/saveItem*').as('saveItem');
             cy.get('[data-testid="save-the-item"]').click();
             cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
@@ -191,7 +191,7 @@ describe('Passage Authoring', () => {
             cy.get(selectorsItem.authoring).click();
             addInteraction(choiceInteraction);
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulus(isCreatedAsset);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt);
             cy.log('ASSET ADDED TO PROMPT');
         });
 
@@ -199,7 +199,7 @@ describe('Passage Authoring', () => {
             const isCreatedAsset = false;
             const isChoice = true;
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulus(isCreatedAsset);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt);
             cy.log('ASSET ADDED TO CHOICE');
         });
 

--- a/views/cypress/tests/add-asset-passage-to-interaction.spec.js
+++ b/views/cypress/tests/add-asset-passage-to-interaction.spec.js
@@ -30,6 +30,7 @@ import { addInteraction } from "../../../../taoQtiItem/views/cypress/utils/autho
 import paths from '../../../../taoQtiItem/views/cypress/utils/paths';
 import { getRandomNumber } from '../../../../tao/views/cypress/utils/helpers';
 import { importSelectedAsset } from '../utils/import-selected-asset'
+import { checkPassageNotEditable } from '../utils/check-read-only'
 
 
 const className = `Test E2E class ${getRandomNumber()}`;
@@ -186,6 +187,18 @@ describe('Passage Authoring', () => {
             cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
             cy.get(`${selectorsItem.manageItems}`).click();
         });
+        it('can check that created passage is read-only and cannot be edited', function () {
+            cy.get(selectorsItem.authoring).click();
+            //check that prompts's paragraph in passage cannot be edited
+            checkPassageNotEditable(isChoice)
+            //check that choice's paragraph in passage cannot be edited
+            let isChoice = true;
+            checkPassageNotEditable(isChoice)
+            cy.intercept('POST', '**/saveItem*').as('saveItem');
+            cy.get('[data-testid="save-the-item"]').click();
+            cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
+            cy.get(`${selectorsItem.manageItems}`).click();
+        });
 
         it('can add imported asset to the prompt ', function () {
             const isCreatedAsset = false;
@@ -198,19 +211,28 @@ describe('Passage Authoring', () => {
             cy.log('ASSET ADDED TO PROMPT');
         });
 
-        it('can add imported asset to the choice ', function () {
+        it('can add imported asset to the choice & safe ', function () {
             const isCreatedAsset = false;
             const isChoice = true;
             addSharedStimulusToInteraction(isChoice)
             selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className, passageName);
             cy.log('ASSET ADDED TO CHOICE');
-        });
-
-        it('can save the item ', function () {
             cy.intercept('POST', '**/saveItem*').as('saveItem');
             cy.get('[data-testid="save-the-item"]').click();
             cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
             cy.log('ITEM SAVED');
+        });
+        it('can check that imported passage is read-only and cannot be edited', function () {
+            //check that prompts's paragraph in passage cannot be edited
+            checkPassageNotEditable(isChoice)
+            //check that choice's paragraph in passage cannot be edited
+            let isChoice = true;
+            checkPassageNotEditable(isChoice)
+            cy.intercept('POST', '**/saveItem*').as('saveItem');
+            cy.get('[data-testid="save-the-item"]').click();
+            cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
+            cy.log('ITEM SAVED');
+            // cy.get(`${selectorsItem.manageItems}`).click();
         });
     });
 });

--- a/views/cypress/tests/add-asset-passage-to-interaction.spec.js
+++ b/views/cypress/tests/add-asset-passage-to-interaction.spec.js
@@ -125,9 +125,9 @@ describe('Passage Authoring', () => {
 
         it('can save passage with A block & content', () => {
              cy.intercept('PATCH', '**/taoMediaManager/SharedStimulus/patch*').as('savePassage');
-             cy.get(selectors.assetAuthoringSaveButton).should('not.be.disabled');
              cy.get(selectors.assetAuthoringSaveButton).click({ force: true });
              cy.wait('@savePassage').its('response.body').its('success').should('eq', true);
+             cy.get(selectors.assetAuthoringSaveButton).should('not.have.class', 'disabled');
              cy.get(`${selectors.manageAssets}`).click();
         });
         it('can import asset', function () {
@@ -144,9 +144,9 @@ describe('Passage Authoring', () => {
 
     describe('item authoring add shared stimulus', () => {
         it('can create an item ', function () {
-            cy.intercept('POST', '**/taoItems/Items/editItem*').as('editItem');
+            cy.intercept('POST', '**/taoItems/Items/editItem*').as('editItems');
             cy.visit(urlsItem.items);
-            cy.wait('@editItem');
+            cy.wait('@editItems');
             // create folder and item
             cy.addClassToRoot(
                 selectorsItem.root,
@@ -171,14 +171,14 @@ describe('Passage Authoring', () => {
             const isCreatedAsset = true;
             const isChoice = false;
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className);
         });
 
         it('can add created passage to the choice & save', function () {
             const isCreatedAsset = true;
             const isChoice = true;
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className);
             cy.intercept('POST', '**/saveItem*').as('saveItem');
             cy.get('[data-testid="save-the-item"]').click();
             cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
@@ -192,7 +192,7 @@ describe('Passage Authoring', () => {
             cy.get(selectorsItem.authoring).click();
             addInteraction(choiceInteraction);
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className);
             cy.log('ASSET ADDED TO PROMPT');
         });
 
@@ -200,7 +200,7 @@ describe('Passage Authoring', () => {
             const isCreatedAsset = false;
             const isChoice = true;
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className);
             cy.log('ASSET ADDED TO CHOICE');
         });
 

--- a/views/cypress/tests/add-asset-passage-to-interaction.spec.js
+++ b/views/cypress/tests/add-asset-passage-to-interaction.spec.js
@@ -33,7 +33,7 @@ import { importSelectedAsset } from '../utils/import-selected-asset'
 
 
 const className = `Test E2E class ${getRandomNumber()}`;
-const itemName = 'Test E2E passage 1';
+const passageName = 'Test E2E passage 1';
 const choiceInteraction = 'choice';
 const ablockContainerParagraph = '.widget-box[data-qti-class="_container"] p';
 const aBlockContainer = '.widget-box[data-qti-class="_container"]';
@@ -62,7 +62,7 @@ describe('Passage Authoring', () => {
             selectors.addSubClassUrl
         );
         cy.addNode(selectors.assetForm, selectors.addAsset);
-        cy.renameSelectedNode(selectors.assetForm, selectors.editAssetUrl, itemName);
+        cy.renameSelectedNode(selectors.assetForm, selectors.editAssetUrl, passageName);
     });
     /**
      * Visit the page
@@ -159,7 +159,7 @@ describe('Passage Authoring', () => {
                 selectorsItem.addSubClassUrl
             );
             cy.addNode(selectorsItem.itemForm, selectorsItem.addItem);
-            cy.renameSelectedNode(selectorsItem.itemForm, selectorsItem.editItemUrl, itemName);
+            cy.renameSelectedNode(selectorsItem.itemForm, selectorsItem.editItemUrl, passageName);
         });
 
         it('can add an interaction to item ', function () {
@@ -173,14 +173,14 @@ describe('Passage Authoring', () => {
             const isCreatedAsset = true;
             const isChoice = false;
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className, passageName);
         });
 
         it('can add created passage to the choice & save', function () {
             const isCreatedAsset = true;
             const isChoice = true;
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className, passageName);
             cy.intercept('POST', '**/saveItem*').as('saveItem');
             cy.get('[data-testid="save-the-item"]').click();
             cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
@@ -194,7 +194,7 @@ describe('Passage Authoring', () => {
             cy.get(selectorsItem.authoring).click();
             addInteraction(choiceInteraction);
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className,passageName);
             cy.log('ASSET ADDED TO PROMPT');
         });
 
@@ -202,7 +202,7 @@ describe('Passage Authoring', () => {
             const isCreatedAsset = false;
             const isChoice = true;
             addSharedStimulusToInteraction(isChoice)
-            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className);
+            selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className, passageName);
             cy.log('ASSET ADDED TO CHOICE');
         });
 

--- a/views/cypress/tests/add-asset-passage-to-interaction.spec.js
+++ b/views/cypress/tests/add-asset-passage-to-interaction.spec.js
@@ -62,7 +62,6 @@ describe('Passage Authoring', () => {
         );
         cy.addNode(selectors.assetForm, selectors.addAsset);
         cy.renameSelectedNode(selectors.assetForm, selectors.editAssetUrl, itemName);
-        // Asset import to go here? or in tests TO DO
     });
     /**
      * Visit the page

--- a/views/cypress/tests/add-asset-passage-to-interaction.spec.js
+++ b/views/cypress/tests/add-asset-passage-to-interaction.spec.js
@@ -128,7 +128,9 @@ describe('Passage Authoring', () => {
              cy.get(selectors.assetAuthoringSaveButton).click({ force: true });
              cy.wait('@savePassage').its('response.body').its('success').should('eq', true);
              cy.get(selectors.assetAuthoringSaveButton).should('not.have.class', 'disabled');
-             cy.get(`${selectors.manageAssets}`).click();
+            cy.intercept('GET', `**/getOntologyData**`).as('treeRender');
+            cy.get(`${selectors.manageAssets}`).click();
+            cy.wait('@treeRender');
         });
         it('can import asset', function () {
             const sharedStimulusName = 'importablepassagepxml.zip';

--- a/views/cypress/tests/add-asset-passage-to-interaction.spec.js
+++ b/views/cypress/tests/add-asset-passage-to-interaction.spec.js
@@ -1,0 +1,194 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+import urls from '../utils/urls';
+import urlsItem from '../../../../taoQtiItem/views/cypress/utils/urls'
+import selectors from '../utils/selectors';
+import selectorsItem from '../../../../taoQtiItem/views/cypress/utils/selectors';
+
+import { selectUploadAssetToClass } from '../utils/resource-manager';
+import {
+    selectUploadSharedStimulus,
+    addSharedStimulusToInteraction
+} from "../../../../taoQtiItem/views/cypress/utils/resource-manager";
+import { addAblock } from '../../../../taoQtiItem/views/cypress/utils/authoring-add-interactions';
+import { addInteraction } from "../../../../taoQtiItem/views/cypress/utils/authoring-add-interactions";
+
+import paths from '../../../../taoQtiItem/views/cypress/utils/paths';
+import { getRandomNumber } from '../../../../tao/views/cypress/utils/helpers';
+
+const className = `Test E2E class ${getRandomNumber()}`;
+const itemName = 'Test E2E passage 1';
+const choiceInteraction = 'choice';
+const ablockContainerParagraph = '.widget-box[data-qti-class="_container"] p';
+const aBlockContainer = '.widget-box[data-qti-class="_container"]';
+
+describe('Passage Authoring', () => {
+    /**
+     * Log in
+     * Visit the page
+     * Create test folder
+     */
+    before(() => {
+        cy.setup(
+            selectors.treeRenderUrl,
+            selectors.editClassLabelUrl,
+            urls.assets,
+            selectors.root
+        );
+
+        cy.addClassToRoot(
+            selectors.root,
+            selectors.assetClassForm,
+            className,
+            selectors.editClassLabelUrl,
+            selectors.treeRenderUrl,
+            selectors.addSubClassUrl
+        );
+        cy.addNode(selectors.assetForm, selectors.addAsset);
+        cy.renameSelectedNode(selectors.assetForm, selectors.editAssetUrl, itemName);
+        // Asset import to go here? or in tests TO DO
+    });
+    /**
+     * Visit the page
+     * Delete test folder
+     */
+    after(() => {
+        cy.log('AFTER')
+        // Delete items class
+        cy.intercept('POST', '**/edit*').as('editItem');
+        cy.visit(urlsItem.items);
+        cy.wait('@editItem');
+
+        cy.deleteClassFromRoot(
+            selectorsItem.root,
+            selectorsItem.itemClassForm,
+            selectorsItem.deleteClass,
+            selectorsItem.deleteConfirm,
+            className,
+            selectorsItem.deleteClassUrl,
+            true
+        );
+        //Delete Asset class
+        cy.intercept('POST', '**/edit*').as('edit');
+        cy.visit(urls.assets);
+        cy.wait('@edit');
+
+        cy.deleteClassFromRoot(
+            selectors.root,
+            selectors.assetClassForm,
+            selectors.deleteClass,
+            selectors.deleteConfirm,
+            className,
+            selectors.deleteClassUrl,
+            true
+        );
+    });
+
+    /**
+     * Tests
+     */
+    describe('Passage authoring', () => {
+        it('can open passage & add content', function () {
+            cy.get(selectors.authoringAsset).click();
+            addAblock();
+        });
+
+        it('can add image to passage', () => {
+            const imageName = 'img-option.png';
+            cy.getSettled(`${aBlockContainer}`).click();
+            cy.get('[id="toolbar-top"]')
+                .find('[class="cke_button cke_button__taoqtiimage cke_button_off"]')
+                .click({ force: true });
+            cy.get('.resourcemgr.modal').should('be.visible');
+            selectUploadAssetToClass(imageName, `${paths.assetsPath}${imageName}`, className).then(() => {
+                cy.log(`${paths.assetsPath}${imageName}`, 'IS ADDED');
+                cy.getSettled(`${ablockContainerParagraph}`).click({ force: true });
+            });
+
+            it('can import some asset (image import shared sitmulus)', () => {
+                //TO DO
+                cy.log('IMAGE AND ASSET IMPORTED')
+            });
+        });
+
+        it('can save passage with A block & content', () => {
+             cy.intercept('PATCH', '**/taoMediaManager/SharedStimulus/patch*').as('savePassage');
+             cy.get(selectors.assetAuthoringSaveButton).click({ force: true });
+             cy.wait('@savePassage').its('response.body').its('success').should('eq', true);
+        });
+     });
+
+    describe('item authoring add shared stimulus', () => {
+        it('can create an item ', function () {
+            cy.intercept('POST', '**/taoItems/Items/editItem*').as('editItem');
+            cy.visit(urlsItem.items);
+            cy.wait('@editItem');
+            // create folder and item
+            cy.addClassToRoot(
+                selectorsItem.root,
+                selectorsItem.itemClassForm,
+                className,
+                selectorsItem.editClassLabelUrl,
+                selectorsItem.treeRenderUrl,
+                selectorsItem.addSubClassUrl
+            );
+            cy.addNode(selectorsItem.itemForm, selectorsItem.addItem);
+            cy.renameSelectedNode(selectorsItem.itemForm, selectorsItem.editItemUrl, itemName);
+        });
+
+        it('can add an interaction to item ', function () {
+            cy.get(selectorsItem.authoring).click();
+            cy.getSettled('.qti-item.item-editor-item.edit-active').should('exist');
+            addInteraction(choiceInteraction);
+            cy.log('INTERACTION ADDED');
+        });
+
+        it('can add created passage to the prompt ', function () {
+            addSharedStimulusToInteraction()
+            selectUploadSharedStimulus();
+        });
+
+        it('can add created passage to the choice ', function () {
+            cy.get('#item-editor-scroll-inner').click();
+            cy.get('.choice-area ')
+                .first()
+                .click();
+            addSharedStimulusToInteraction()
+            selectUploadSharedStimulus();
+        });
+
+        it('can add created asset to the prompt ', function () {
+            // TO DO
+            cy.log('ASSET ADDED TO PROMPT');
+        });
+
+        it('can add created asset to the choice ', function () {
+            //TO DO
+            cy.log('ASSET ADDED TO CHOICE');
+        });
+
+        it('can save the item ', function () {
+            cy.intercept('POST', '**/saveItem*').as('saveItem');
+            cy.get('[data-testid="save-the-item"]').click();
+            cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
+            cy.log('ITEM SAVED');
+        });
+
+    });
+});

--- a/views/cypress/utils/check-read-only.js
+++ b/views/cypress/utils/check-read-only.js
@@ -1,0 +1,38 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 Open Assessment Technologies SA ;
+ */
+
+
+/**
+ * check that the selected asset is read only
+ * @param {Boolean} isChoice specifies if the selector is choice (vs prompt)
+ *
+ */
+
+export function checkPassageNotEditable(isChoice = false){
+    cy.get('[contenteditable="false"]').should('exist');
+    cy.getSettled('#item-editor-scoll-container').click();
+    cy.get('.qti-prompt-container').click();
+    if (isChoice){
+        cy.get('.qti-prompt-container').click();
+    } else {
+        cy.get('.choice-area ').find('[data-identifier="choice_2"]').click({force:true});
+    }
+    cy.get('.qti-include').last().click({force: true});
+    cy.getSettled('#toolbar-top').should('have.css','display', 'none');
+    cy.log('CONFIRMED ASSET NOT EDITABLE');
+}

--- a/views/cypress/utils/import-selected-asset.js
+++ b/views/cypress/utils/import-selected-asset.js
@@ -1,0 +1,41 @@
+/**
+ * Imports resource in class (class should already be selected before running this command)
+ * @param {String} importSelector - css selector for the import button
+ * @param {String} importFilePath - path to the file to import
+ * @param {String} importUrl - url for the resource import POST request
+ * @param {String} className
+ */
+export function importSelectedAsset(importSelector, importFilePath, importUrl, className) {
+    cy.log('COMMAND: import', importUrl);
+    cy.get(importSelector).click();
+
+    cy.readFile(importFilePath, 'binary')
+        .then(fileContent => {
+            cy.get('input[type="file"][name="content"]')
+                .attachFile({
+                        fileContent,
+                        filePath: importFilePath,
+                        encoding: 'binary',
+                        lastModified: new Date().getTime()
+                    }
+                );
+            cy.get('.progressbar.success').should('exist');
+            cy.intercept('POST', `**/${importUrl}**`).as('import').get('.form-toolbar button')
+                .click()
+            cy.get('.actions [data-trigger="continue"]').click();
+
+            return cy.isElementPresent('.task-report-container')
+                .then(isTaskStatus => {
+                    if (isTaskStatus) {
+                        cy.get('.feedback-success.hierarchical').should('exist');
+                    } else {
+                        // task was moved to the task queue (background)
+                        cy.get('.badge-component').click();
+                        cy.get('.task-element.completed').first().contains(className);
+                        // close the task manager
+                        cy.get('.badge-component').click();
+                  }
+             })
+        });
+        cy.log('Asset imported');
+}

--- a/views/cypress/utils/resource-manager.js
+++ b/views/cypress/utils/resource-manager.js
@@ -49,7 +49,7 @@ export function selectUploadAssetToClass(fileName, pathToFile, className) {
  * * @param {boolean} isCreatedAsset determines whether the asset is
  * the one previously created (vs imported)
  */
-export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt) {
+export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className) {
     cy.log('SELECT OR UPLOAD SHARED STIMULUS',);
     return cy.get('.resourcemgr.modal')
         .last()
@@ -57,6 +57,7 @@ export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt) {
             const resourcemgrId = resourcemgr[0].id;
             cy.getSettled(`#${resourcemgrId} .file-browser .root-folder`).should('exist');
             cy.getSettled(`.mediamanager .folders .root`).should('exist');
+            cy.get(`#${resourcemgrId} .file-browser .mediamanager .folders`).contains(className).click();
             cy.getSettled(`#${resourcemgrId} .mediamanager .folders .root ul > li`)
                 .first()
                 .click();
@@ -76,6 +77,6 @@ export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt) {
                     .last()
                     .click();
             }
-            cy.getSettled('[class="qti-include"]').should('exist')
+            cy.getSettled('[class="qti-include"] div').should('exist');
         });
 }

--- a/views/cypress/utils/resource-manager.js
+++ b/views/cypress/utils/resource-manager.js
@@ -58,9 +58,6 @@ export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, classN
             cy.getSettled(`#${resourcemgrId} .file-browser .root-folder`).should('exist');
             cy.getSettled(`.mediamanager .folders .root`).should('exist');
             cy.get(`#${resourcemgrId} .file-browser .mediamanager .folders`).contains(className).click();
-            cy.getSettled(`#${resourcemgrId} .mediamanager .folders .root ul > li`)
-                .first()
-                .click();
             cy.getSettled(`.file-selector .files  [data-alt="${dataAlt}"]`).should('exist');
             if(isCreatedAsset){
                 cy.getSettled(`#${resourcemgrId} ul > li[data-type="html"]`)

--- a/views/cypress/utils/resource-manager.js
+++ b/views/cypress/utils/resource-manager.js
@@ -43,3 +43,38 @@ export function selectUploadAssetToClass(fileName, pathToFile, className) {
             cy.getSettled(`#${resourcemgrId} li[data-alt="${fileName}"] .actions a.select`).last().click();
         });
 }
+
+/**
+ * Add/upload shared stimulus to Item interaction
+ * * @param {boolean} isCreatedAsset determines whether the asset is
+ * the one previously created (vs imported)
+ */
+export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt) {
+    cy.log('SELECT OR UPLOAD SHARED STIMULUS',);
+    return cy.get('.resourcemgr.modal')
+        .last()
+        .then(resourcemgr => {
+            const resourcemgrId = resourcemgr[0].id;
+            cy.getSettled(`#${resourcemgrId} .file-browser .root-folder`).should('exist');
+            cy.getSettled(`.mediamanager .folders .root`).should('exist');
+            cy.getSettled(`#${resourcemgrId} .mediamanager .folders .root ul > li`)
+                .first()
+                .click();
+            cy.getSettled(`.file-selector .files  [data-alt="${dataAlt}"]`).should('exist');
+            if(isCreatedAsset){
+                cy.getSettled(`#${resourcemgrId} ul > li[data-type="html"]`)
+                    .first()
+                    .click();
+                cy.get(`#${resourcemgrId} li > .actions a.select`)
+                    .first()
+                    .click();
+            } else {
+                cy.getSettled(`#${resourcemgrId} ul > li[data-type="html"]`)
+                    .last()
+                    .click();
+                cy.get(`#${resourcemgrId} li > .actions a.select`)
+                    .last()
+                    .click();
+            }
+        });
+}

--- a/views/cypress/utils/resource-manager.js
+++ b/views/cypress/utils/resource-manager.js
@@ -49,7 +49,7 @@ export function selectUploadAssetToClass(fileName, pathToFile, className) {
  * * @param {boolean} isCreatedAsset determines whether the asset is
  * the one previously created (vs imported)
  */
-export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className) {
+export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className, passageName) {
     cy.log('SELECT OR UPLOAD SHARED STIMULUS',);
     return cy.get('.resourcemgr.modal')
         .last()
@@ -61,14 +61,14 @@ export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, classN
             cy.getSettled(`.file-selector .files  [data-alt="${dataAlt}"]`).should('exist');
             if(isCreatedAsset){
                 cy.getSettled(`#${resourcemgrId} ul > li[data-type="html"]`)
-                    .first()
+                    .contains(passageName)
                     .click();
                 cy.get(`#${resourcemgrId} li > .actions a.select`)
                     .first()
                     .click();
             } else {
                 cy.getSettled(`#${resourcemgrId} ul > li[data-type="html"]`)
-                    .last()
+                    .contains('sharedStimulus')
                     .click();
                 cy.get(`#${resourcemgrId} li > .actions a.select`)
                     .last()

--- a/views/cypress/utils/resource-manager.js
+++ b/views/cypress/utils/resource-manager.js
@@ -76,5 +76,6 @@ export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt) {
                     .last()
                     .click();
             }
+            cy.getSettled('[class="qti-include"]').should('exist')
         });
 }

--- a/views/cypress/utils/resource-manager.js
+++ b/views/cypress/utils/resource-manager.js
@@ -62,16 +62,14 @@ export function selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, classN
             if(isCreatedAsset){
                 cy.getSettled(`#${resourcemgrId} ul > li[data-type="html"]`)
                     .contains(passageName)
-                    .click();
-                cy.get(`#${resourcemgrId} li > .actions a.select`)
-                    .first()
+                    .siblings('.actions')
+                    .find('a[title="Select this file"]')
                     .click();
             } else {
                 cy.getSettled(`#${resourcemgrId} ul > li[data-type="html"]`)
                     .contains('sharedStimulus')
-                    .click();
-                cy.get(`#${resourcemgrId} li > .actions a.select`)
-                    .last()
+                    .siblings('.actions')
+                    .find('a[title="Select this file"]')
                     .click();
             }
             cy.getSettled('[class="qti-include"] div').should('exist');

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -18,6 +18,9 @@ export default {
     editClassLabelUrl: 'taoMediaManager/MediaManager/editClassLabel',
     editAssetUrl: 'taoMediaManager/MediaManager/editInstance',
 
+    importAsset: '#media-import',
+    importAssetUrl: 'taoMediaManager/MediaImport/index',
+
     moveClass: '[id="media-move-to"][data-context="resource"][data-action="moveTo"]',
     moveConfirmSelector: 'button[data-control="ok"]',
 


### PR DESCRIPTION
**End to end testing.**
Related to: https://oat-sa.atlassian.net/browse/AUT-1195
Depends on :

- https://github.com/oat-sa/extension-tao-itemqti/pull/1960
- https://github.com/oat-sa/tao-core/pull/3250

**Description of changes:**
Creation of E2E tests for: Creating and importing passages/asset and adding to prompt and choice of interaction
**How to run locally:**
Checkout to branch  `feature/AUT-1195/e2e-add-asset-passage-to-interaction`
in extensions:

- https://github.com/oat-sa/tao-core
- https://github.com/oat-sa/extension-tao-itemqti
- https://github.com/oat-sa/extension-tao-mediamanager

**run tests from tao core extn:**
npm run[ cy:open](url) - to run in browser
or npm run` cy:run` - for headless execution
File to test: `add-asset-passage-to-interaction.spec.js`
All tests should pass:
![image](https://user-images.githubusercontent.com/60346520/143610096-73afab82-8e72-4970-9589-e21cb06c807b.png)
