### PR TITLE
[AUT-1538] Fixed failed to import passage with no stylesheet

### DIFF
--- a/model/sharedStimulus/service/PatchService.php
+++ b/model/sharedStimulus/service/PatchService.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace oat\taoMediaManager\model\sharedStimulus\service;
 
-use core_kernel_classes_Class;
 use core_kernel_classes_Literal;
 use core_kernel_classes_Resource as Resource;
 use core_kernel_persistence_Exception;
@@ -39,14 +38,13 @@ use oat\tao\model\media\TaoMediaResolver;
 use oat\taoMediaManager\model\fileManagement\FileSourceUnserializer;
 use oat\taoMediaManager\model\fileManagement\FlySystemManagement;
 use oat\taoMediaManager\model\MediaService;
-use oat\taoMediaManager\model\relation\event\MediaSavedEventDispatcher;
 use oat\taoMediaManager\model\sharedStimulus\parser\SharedStimulusMediaExtractor;
 use oat\taoMediaManager\model\sharedStimulus\PatchCommand;
 use oat\taoMediaManager\model\sharedStimulus\SharedStimulus;
 use oat\taoMediaManager\model\SharedStimulusImporter;
 use qtism\data\storage\xml\XmlStorageException;
+use tao_helpers_I18n;
 use tao_models_classes_FileNotFoundException as FileNotFoundException;
-use tao_models_classes_LanguageService;
 
 class PatchService extends ConfigurableService
 {
@@ -171,8 +169,7 @@ class PatchService extends ConfigurableService
 
     private function findLanguageResource(core_kernel_classes_Literal $resourceLanguage): Resource
     {
-        $userClass = new core_kernel_classes_Class(tao_models_classes_LanguageService::CLASS_URI_LANGUAGES);
-        $resourceLanguage = current($userClass->searchInstances([RDF_VALUE => (string)$resourceLanguage]));
+        $resourceLanguage = tao_helpers_I18n::getLangResourceByCode((string)$resourceLanguage);
         if (!$resourceLanguage instanceof Resource) {
             throw new LogicException(sprintf("Fail to find the resource of %s", (string)$resourceLanguage));
         }

--- a/model/sharedStimulus/service/StoreService.php
+++ b/model/sharedStimulus/service/StoreService.php
@@ -52,6 +52,16 @@ class StoreService extends ConfigurableService
         if (count($cssFiles)) {
             $fs->createDir($dirname . DIRECTORY_SEPARATOR . self::CSS_DIR_NAME);
             foreach ($cssFiles as $file) {
+                if (!file_exists($file)) {
+                    $this->getLogger()->notice(sprintf("file %s does not exist", $file));
+                    continue;
+                }
+
+                if (!is_readable($file)) {
+                    $this->getLogger()->notice(sprintf("file %s is not readable", $file));
+                    continue;
+                }
+
                 $fs->putStream(
                     $dirname . DIRECTORY_SEPARATOR . self::CSS_DIR_NAME . DIRECTORY_SEPARATOR . basename($file),
                     fopen($file, 'r')


### PR DESCRIPTION
This ticket is intended to fix the issue: https://oat-sa.atlassian.net/browse/AUT-1538

The issue happens when an item is imported with a passage which has not stylesheet. The solution proposed is to do not return an an error for this case. 

During the authoring of these imported passages, we were not able to author it because of for some reason, the expected language is not a resource, but a literal one. I just converted to a resource in cause of this issue happens.