### PR TITLE
feat(e2e): added tests to check that passage is not editable in item …

### DIFF
--- a/views/cypress/tests/add-asset-passage-to-interaction.spec.js
+++ b/views/cypress/tests/add-asset-passage-to-interaction.spec.js
@@ -30,6 +30,7 @@ import { addInteraction } from "../../../../taoQtiItem/views/cypress/utils/autho
 import paths from '../../../../taoQtiItem/views/cypress/utils/paths';
 import { getRandomNumber } from '../../../../tao/views/cypress/utils/helpers';
 import { importSelectedAsset } from '../utils/import-selected-asset'
+import { checkPassageNotEditable } from '../utils/check-read-only'
 
 
 const className = `Test E2E class ${getRandomNumber()}`;
@@ -184,6 +185,18 @@ describe('Passage Authoring', () => {
             cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
             cy.get(`${selectorsItem.manageItems}`).click();
         });
+        it('can check that created passage is read-only and cannot be edited', function () {
+            cy.get(selectorsItem.authoring).click();
+            //check that prompts's paragraph in passage cannot be edited
+            checkPassageNotEditable(isChoice)
+            //check that choice's paragraph in passage cannot be edited
+            let isChoice = true;
+            checkPassageNotEditable(isChoice)
+            cy.intercept('POST', '**/saveItem*').as('saveItem');
+            cy.get('[data-testid="save-the-item"]').click();
+            cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
+            cy.get(`${selectorsItem.manageItems}`).click();
+        });
 
         it('can add imported asset to the prompt ', function () {
             const isCreatedAsset = false;
@@ -196,19 +209,28 @@ describe('Passage Authoring', () => {
             cy.log('ASSET ADDED TO PROMPT');
         });
 
-        it('can add imported asset to the choice ', function () {
+        it('can add imported asset to the choice & safe ', function () {
             const isCreatedAsset = false;
             const isChoice = true;
             addSharedStimulusToInteraction(isChoice)
             selectUploadSharedStimulusToItem(isCreatedAsset, dataAlt, className);
             cy.log('ASSET ADDED TO CHOICE');
-        });
-
-        it('can save the item ', function () {
             cy.intercept('POST', '**/saveItem*').as('saveItem');
             cy.get('[data-testid="save-the-item"]').click();
             cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
             cy.log('ITEM SAVED');
+        });
+        it('can check that imported passage is read-only and cannot be edited', function () {
+            //check that prompts's paragraph in passage cannot be edited
+            checkPassageNotEditable(isChoice)
+            //check that choice's paragraph in passage cannot be edited
+            let isChoice = true;
+            checkPassageNotEditable(isChoice)
+            cy.intercept('POST', '**/saveItem*').as('saveItem');
+            cy.get('[data-testid="save-the-item"]').click();
+            cy.wait('@saveItem').its('response.body').its('success').should('eq', true);
+            cy.log('ITEM SAVED');
+            // cy.get(`${selectorsItem.manageItems}`).click();
         });
     });
 });

--- a/views/cypress/utils/check-read-only.js
+++ b/views/cypress/utils/check-read-only.js
@@ -1,0 +1,38 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 Open Assessment Technologies SA ;
+ */
+
+
+/**
+ * check that the selected asset is read only
+ * @param {Boolean} isChoice specifies if the selector is choice (vs prompt)
+ *
+ */
+
+export function checkPassageNotEditable(isChoice = false){
+    cy.get('[contenteditable="false"]').should('exist');
+    cy.getSettled('#item-editor-scoll-container').click();
+    cy.get('.qti-prompt-container').click();
+    if (isChoice){
+        cy.get('.qti-prompt-container').click();
+    } else {
+        cy.get('.choice-area ').find('[data-identifier="choice_2"]').click({force:true});
+    }
+    cy.get('.qti-include').last().click({force: true});
+    cy.getSettled('#toolbar-top').should('have.css','display', 'none');
+    cy.log('CONFIRMED ASSET NOT EDITABLE');
+}


### PR DESCRIPTION
**End to end testing.**
Related to: https://oat-sa.atlassian.net/browse/AUT-1196

Description of changes:
Creation of E2E tests for: Check that passage in Item authoring is not editable
How to run locally:
Checkout to branch feature/AUT-1196/e2e-tests-passage-no-editable-in-item

run tests from tao core extn:
npm run cy:open - to run in browser
or npm run cy:run - for headless execution
File to test: add-asset-passage-to-interaction.spec.js
All tests should pass:
![image](https://user-images.githubusercontent.com/60346520/144602143-20712deb-d28c-4e89-aba6-898744ba17a1.png)