### PR TITLE
fix: add missing items variable

### DIFF
--- a/views/js/controller/actions.js
+++ b/views/js/controller/actions.js
@@ -146,7 +146,8 @@ define([
                         message = relatedItemsPopupTpl({
                             name,
                             inUsageMessage:  __('This "%s" is currently used in %d item(s)', name, haveItemReferences.length),
-                            confirmationMessage: __('Are you sure you want to delete this "%s"?', name)
+                            confirmationMessage: __('Are you sure you want to delete this "%s"?', name),
+                            items: haveItemReferences
                         });
                     }
                 } else if (actionContext.context[0] !== 'instance') {


### PR DESCRIPTION
**Description**
Fix warning message when try to delete an asset used in item or passage.
The bug is not showing list of items in warning popup

**Ticket**
https://oat-sa.atlassian.net/browse/REL-612