### PR TITLE
feat: use new middleware to patch validation

### DIFF
--- a/controller/Middleware/MiddlewareConfig.php
+++ b/controller/Middleware/MiddlewareConfig.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoMediaManager\controller\Middleware;
+
+use oat\generis\model\Middleware\MiddlewareMap;
+use oat\generis\model\Middleware\MiddlewareConfigInterface;
+use oat\tao\model\Middleware\OpenAPISchemaValidateRequestMiddleware;
+
+class MiddlewareConfig implements MiddlewareConfigInterface
+{
+    public function __invoke(): array
+    {
+        return [
+            MiddlewareMap::perRoute(
+                '/taoMediaManager/SharedStimulus/patch',
+                [
+                    OpenAPISchemaValidateRequestMiddleware::SERVICE_ID,
+                ],
+                [
+                    'PATCH',
+                ]
+            ),
+        ];
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -19,6 +19,7 @@
  */
 
 use oat\taoItems\model\user\TaoItemsRoles;
+use oat\taoMediaManager\controller\Middleware\MiddlewareConfig;
 use oat\taoMediaManager\model\export\service\MediaResourcePreparer;
 use oat\taoMediaManager\scripts\install\RegisterMediaResourcePreparer;
 use oat\taoMediaManager\scripts\install\SetMediaManager;
@@ -219,5 +220,8 @@ return [
     ],
     'containerServiceProviders' => [
         MediaServiceProvider::class,
+    ],
+    'middlewares' => [
+        MiddlewareConfig::class,
     ],
 ];


### PR DESCRIPTION
Task: https://oat-sa.atlassian.net/browse/ADF-731

## Solution

Added middleware support in generis  and make it able to store configs on container cache and be set by proper configuration standard

Documentation: https://github.com/oat-sa/generis/blob/feat/ADF-731/middleware-di-container/core/Middleware/README.md

## TODO

- [ ] Unit tests
- [ ] Fix middleware behavior