### PR TITLE
fix: clear rich passage styles in item Authoring after exit

### DIFF
--- a/views/js/richPassage/xincludeRendererAddStyles.js
+++ b/views/js/richPassage/xincludeRendererAddStyles.js
@@ -33,7 +33,8 @@ define(['jquery', 'uri', 'util/url', 'core/dataProvider/request'], function ($, 
                             href: urlUtil.route('loadStylesheet', 'SharedStimulusStyling', 'taoMediaManager', {
                                 uri: passageUri,
                                 stylesheet: element
-                            })
+                            }),
+                            'data-serial': passageUri
                         });
                         head.append(styleElem);
                     });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2028

All styles with `[data-serial]` will be removed by styleEditor according this code https://github.com/oat-sa/extension-tao-itemqti/blob/02fb1822e4d503069cc7a10c56d206a387766c68/views/js/qtiCreator/editor/styleEditor/styleEditor.js#L368 after exit from item Authoring

## How to test:

- Create shared stimulus with styles
- Create a item with this shared stimulus
- Open new tab with media, editing the shared stimulus, remove styles, save
- Going back to the tab with item, closing the item by "mange items"
- Then clicking "authoring again"

**Actual:** The shared stimulus styles still present
**Expected:** The item is updated with the new change in shared stimulus.