### PR TITLE
fix: Do not use shared stimulus importer for media zipfiles

### DIFF
--- a/model/FileImporter.php
+++ b/model/FileImporter.php
@@ -15,9 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
- *
- *
+ * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoMediaManager\model;
@@ -180,12 +178,13 @@ class FileImporter implements
     /**
      * Get the zip importer for shared stimulus
      *
-     * @return SharedStimulusPackageImporter
+     * @return ZipImporter
      */
     protected function getZipImporter()
     {
-        $zipImporter = new SharedStimulusPackageImporter();
+        $zipImporter = new ZipImporter();
         $zipImporter->setServiceLocator($this->getServiceLocator());
+
         return $zipImporter;
     }
 }


### PR DESCRIPTION
**Associated Jira issue:** [ADF-1073](https://oat-sa.atlassian.net/browse/ADF-1073)

The `FileImporter` import handler is using `SharedStimulusPackageImporter` instead of `ZipImporter` to handle file uploads when the user sends a zip file expecting to create various assets in bulk. This change seems to be introduced by mistake as part of https://github.com/oat-sa/extension-tao-mediamanager/pull/139.

After this change, we can still import a shared stimulus by uploading the corresponding zip file **and** selecting "Shared stimulus" as the import format.