### PR TITLE
Feat/aut 2545/prevent internal stylesheet from editor

### DIFF
--- a/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
+++ b/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
@@ -45,12 +45,6 @@
 
                             <ul class="none" id="style-sheet-toggler">
                                 <!-- TAO style sheet -->
-                                <li data-css-res="taoQtiItem/views/css/themes/default.css" data-custom-css="custom-css">
-                                    <span class="icon-preview style-sheet-toggler"
-                                        title="{{__ 'Disable this stylesheet temporarily'}}"></span>
-                                    <span>{{__ 'TAO default styles'}}</span>
-                                </li>
-
                             </ul>
                             <button id="stylesheet-uploader" class="btn-info small block">{{__ 'Add Style Sheet'}}</button>
                         </div>

--- a/views/js/qtiCreator/editor/styleEditor/styleSheetToggler.js
+++ b/views/js/qtiCreator/editor/styleEditor/styleSheetToggler.js
@@ -86,8 +86,9 @@ define([
                 uploader.resourcemgr({
                     className: 'stylesheets',
                     appendContainer: '#mediaManager',
-                    pathParam: 'path',
+                    pathParam: 'stylesheet',
                     path: 'taomedia://mediamanager/',
+                    stylesheet: 'taomedia://mediamanager/',
                     root: 'local',
                     browseUrl: urlUtil.route('getStylesheets', 'SharedStimulusStyling', 'taoMediaManager'),
                     uploadUrl: urlUtil.route('upload', 'SharedStimulusStyling', 'taoMediaManager'),


### PR DESCRIPTION
**Related to:** [AUT-2545](https://oat-sa.atlassian.net/browse/AUT-2545)

**Description:**
Prevent issues with the **tao-user-styles**. 
Hide it on the stylesheet panel, and leave only the download action on the MediaManager modal.


**Changes:**

- Remove the **tao-user-styles** from the stylesheet panel editor.
- Fix the stylesheet download URL on the media manager modal.
- Hide select and delete actions on the media manager modal for the **tao-user-styles** and show the download action.

**How to check:**

- Check the stylesheet panel to see if **tao-user-styles** is hidden.
- Add some custom styles on the panel
- Open the media manager modal to add a new CSS file.
- Check the actions of the file on the media manager modal: 
      - Only select for new CSS stylesheet. 
      - Only download for **tao-user.styles**. 
- Download the tao-user-styles file and check if the file is ok.
