### PR TITLE
Fix/aut 2637/fix style passage text block

### DIFF
--- a/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
+++ b/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
@@ -88,7 +88,7 @@
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom text color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="color"
-                                              data-target="body div.qti-item .mainClass *"></button>
+                                              data-target="body div.qti-item .mainClass"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Border color'}}</label>
@@ -204,7 +204,7 @@
 
                             <div class="reset-group">
                                 <select
-                                    data-target="body div.qti-item .mainClass .custom-text-box.hashClass .custom-text-box.hashClass *"
+                                    data-target="body div.qti-item .mainClass .custom-text-box.hashClass *"
                                     id="item-editor-font-selector"
                                     data-has-search="false"
                                     data-placeholder="{{__ 'Default'}}"

--- a/views/js/qtiCreator/editor/styleEditor/colorSelector.js
+++ b/views/js/qtiCreator/editor/styleEditor/colorSelector.js
@@ -81,7 +81,7 @@ define([
                     value = style[target][$trigger.data('value')].replace(' !important', '');
                     $trigger.css('background-color', value);
                     $trigger.attr('title', rgbToHex(value));
-                } if (style[targetOld] && style[targetOld][$trigger.data('value')]) {
+                } else if (style[targetOld] && style[targetOld][$trigger.data('value')]) {
                     value = style[targetOld][$trigger.data('value')].replace(' !important', '');
                     $trigger.css('background-color', value);
                     $trigger.attr('title', rgbToHex(value));

--- a/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
+++ b/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
@@ -36,7 +36,7 @@ define(['jquery', 'lodash', 'taoMediaManager/qtiCreator/editor/styleEditor/style
         const figcaptionSelector = `${itemSelector} figure figcaption`;
         const $resetBtn = $fontSizeChanger.parents('.reset-group').find('[data-role="font-size-reset"]');
         const $input = $container.find('.item-editor-font-size-text');
-        let itemFontSize = parseInt($(itemSelector).css('font-size'), 10);
+        let itemFontSize = parseInt($(itemSelector).css('font-size'), 10) || 14;
 
         // initiate font-size for Block
         const styles = styleEditor.getStyle() || {};

--- a/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
+++ b/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
@@ -44,7 +44,7 @@ define(['jquery', 'lodash', 'taoMediaManager/qtiCreator/editor/styleEditor/style
         if (styles[itemSelector] && styles[itemSelector]['font-size']) {
             itemFontSize = parseInt(styles[itemSelector]['font-size'], 10);
             $input.val(itemFontSize);
-        }  if (styles[itemSelectorOld] && styles[itemSelectorOld]['font-size']) {
+        } else if (styles[itemSelectorOld] && styles[itemSelectorOld]['font-size']) {
             itemFontSize = parseInt(styles[itemSelectorOld]['font-size'], 10);
             $input.val(itemFontSize);
         } else {
@@ -122,7 +122,7 @@ define(['jquery', 'lodash', 'taoMediaManager/qtiCreator/editor/styleEditor/style
             if (style[itemSelector] && style[itemSelector]['font-size']) {
                 itemFontSize = parseInt(style[itemSelector]['font-size'], 10);
                 $input.val(itemFontSize);
-            } if (style[itemSelectorOld] && style[itemSelectorOld]['font-size']) {
+            } else if (style[itemSelectorOld] && style[itemSelectorOld]['font-size']) {
                 itemFontSize = parseInt(style[itemSelectorOld]['font-size'], 10);
                 $input.val(itemFontSize);
             } else {


### PR DESCRIPTION
**Related to:** 
[AUT-2656](https://oat-sa.atlassian.net/browse/AUT-2656)
[AUT-2637](https://oat-sa.atlassian.net/browse/AUT-2637)
[AUT-2658](https://oat-sa.atlassian.net/browse/AUT-2658)

**Description:**
Problems with Passage style to show values. 
The saving wasn't a problem, but the value showed on the right panel.

**Changes:**
- Fixed the text-color data-target value on Passage style
- Add `else` to the condition block to avoid overriding the colour value for the Text-block style
- Add `else` to the condition block to avoid overriding the font size value for the Text-block style
- Add default font size to avoid NaN case on resizing Font Size on Passage style

**How to check:**

- Check all colours are shown on the Passage style and Text-block style
- Check Fonts-family are shown on the Passage style and Text-block style
- Check Fonts-size are changed on the Passage style and Text-block style