### PR TITLE
Fix/AUT-2589/edit table caption issues

### DIFF
--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -123,7 +123,9 @@ define([
                     if (options.data && options.data.container && options.data.widget) {
                         const $newImgPlaceholder = $editable.find('[data-new="true"][data-qti-class="img"]');
                         if ($newImgPlaceholder.length &&
-                            !$editable.closest('.qti-simpleChoice').length) {
+                            !$editable.closest('.qti-choice, .qti-flow-container').length &&
+                            !$newImgPlaceholder.closest('.qti-table caption').length
+                        ) {
                             // instead img will add figure element
                             $newImgPlaceholder.attr('data-qti-class','figure');
                             // span after for new line

--- a/views/js/qtiCreator/widgets/static/table/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/table/states/Active.js
@@ -66,11 +66,54 @@ define([
             this.buildEditor();
         },
         function exit() {
+                        // fix a caption on exit
+            // on Enter ckeditor creates an additional caption
+            // move all contents from second caption and others to the first caption
+            // second caption and others will be removed
+            const $editableContainer = this.widget.$container;
+            const $caption = $('caption', $editableContainer);
+            if ($caption.length > 1) {
+                const $first = $caption.first();
+                $caption.each(function (i) {
+                    if (i > 0) {
+                        const $curCap = $(this);
+                        if ($first.html() !== '<br>') {
+                            $first.append('<br>');
+                        }
+                        $first.append($curCap);
+                        replaceElementByItsContent($curCap);
+                    }
+                });
+                $first.focus();
+            }
+            // on alignment ckeditor adds a paragraph
+            // move content from the paragraph to the caption, the paragraph will be removed
+            // set alignment's class to the caption
+            const $paragraphsInCaption = $('caption > p', $editableContainer);
+            if ($paragraphsInCaption.length > 0) {
+                $paragraphsInCaption.each(function () {
+                    const $p = $(this);
+                    const classNames = $p.attr('class');
+                    if (classNames) {
+                        $caption.removeClass();
+                        $caption.addClass(classNames);
+                    }
+                    replaceElementByItsContent($p);
+                });
+            }
+            // after exit will be called getChangeCallback by ckeditor to update container.body with new html
             this.widget.$form.empty();
             this.destroyEditor();
         }
     );
 
+    function replaceElementByItsContent($elem) {
+        if ($elem.children().length) {
+            $elem.children(0).unwrap();
+        } else {
+            $elem.replaceWith($elem.html());
+        }
+    }
     // the element body should only contain the <table> tag content, and not the <table> tag itself.
     // as the ckeditor instance is bound to a wrapping <div>, we need to go through an extra step to remove the <table> tag.
     function getChangeCallback(container) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2589

**How to reproduce:**

- Creating an item
- Adding A-block
- Adding a table with caption
- Aligning the caption to the right
- Saving --> could not be saved

**Issue:** in QTI we can't use tag `<p>`inside `caption`.
**Solution:** move alignment class to `caption`

**Other fixed issue:** 
1. QTI doesn't allow `figure` in `caption`, will be `img`
2. on `Enter` inserted new line that is new `caption`. Copied content of new `caption` to first `caption`