### PR TITLE
fix: remove * from data-target so styles don't get to children elements

### DIFF
--- a/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
+++ b/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
@@ -88,7 +88,7 @@
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom text color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="color"
-                                              data-target="body div.qti-item .mainClass *"></button>
+                                              data-target="body div.qti-item .mainClass"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Border color'}}</label>
@@ -171,21 +171,21 @@
                                         <button class="icon-eraser reset-button" data-value="background-color"
                                               aria-label="{{__ 'Remove custom background color'}}"></button>
                                         <button class="color-trigger" id="initial-bg" data-value="background-color"
-                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass *" data-additional="padding:20px;margin-bottom: 0;"></button>
+                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass " data-additional="padding:20px;margin-bottom: 0;"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Text color'}}</label>
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom text color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="color"
-                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass *"></button>
+                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass "></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Border color'}}</label>
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom border color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="border-color"
-                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass *" data-additional="border-width:4px;border-style:solid;padding:20px"></button>
+                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass" data-additional="border-width:4px;border-style:solid;padding:20px"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Table headings'}}</label>

--- a/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
+++ b/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
@@ -171,14 +171,14 @@
                                         <button class="icon-eraser reset-button" data-value="background-color"
                                               aria-label="{{__ 'Remove custom background color'}}"></button>
                                         <button class="color-trigger" id="initial-bg" data-value="background-color"
-                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass " data-additional="padding:20px;margin-bottom: 0;"></button>
+                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass" data-additional="padding:20px;margin-bottom: 0;"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Text color'}}</label>
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom text color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="color"
-                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass "></button>
+                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Border color'}}</label>

--- a/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
+++ b/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
@@ -204,7 +204,7 @@
 
                             <div class="reset-group">
                                 <select
-                                    data-target="body div.qti-item .mainClass .custom-text-box.hashClass .custom-text-box.hashClass *"
+                                    data-target="body div.qti-item .mainClass .custom-text-box.hashClass *"
                                     id="item-editor-font-selector"
                                     data-has-search="false"
                                     data-placeholder="{{__ 'Default'}}"

--- a/views/js/qtiCreator/editor/styleEditor/colorSelector.js
+++ b/views/js/qtiCreator/editor/styleEditor/colorSelector.js
@@ -81,7 +81,7 @@ define([
                     value = style[target][$trigger.data('value')].replace(' !important', '');
                     $trigger.css('background-color', value);
                     $trigger.attr('title', rgbToHex(value));
-                } if (style[targetOld] && style[targetOld][$trigger.data('value')]) {
+                } else if (style[targetOld] && style[targetOld][$trigger.data('value')]) {
                     value = style[targetOld][$trigger.data('value')].replace(' !important', '');
                     $trigger.css('background-color', value);
                     $trigger.attr('title', rgbToHex(value));

--- a/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
+++ b/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
@@ -36,7 +36,7 @@ define(['jquery', 'lodash', 'taoMediaManager/qtiCreator/editor/styleEditor/style
         const figcaptionSelector = `${itemSelector} figure figcaption`;
         const $resetBtn = $fontSizeChanger.parents('.reset-group').find('[data-role="font-size-reset"]');
         const $input = $container.find('.item-editor-font-size-text');
-        let itemFontSize = parseInt($(itemSelector).css('font-size'), 10);
+        let itemFontSize = parseInt($(itemSelector).css('font-size'), 10) || 14;
 
         // initiate font-size for Block
         const styles = styleEditor.getStyle() || {};
@@ -44,7 +44,7 @@ define(['jquery', 'lodash', 'taoMediaManager/qtiCreator/editor/styleEditor/style
         if (styles[itemSelector] && styles[itemSelector]['font-size']) {
             itemFontSize = parseInt(styles[itemSelector]['font-size'], 10);
             $input.val(itemFontSize);
-        }  if (styles[itemSelectorOld] && styles[itemSelectorOld]['font-size']) {
+        } else if (styles[itemSelectorOld] && styles[itemSelectorOld]['font-size']) {
             itemFontSize = parseInt(styles[itemSelectorOld]['font-size'], 10);
             $input.val(itemFontSize);
         } else {
@@ -122,7 +122,7 @@ define(['jquery', 'lodash', 'taoMediaManager/qtiCreator/editor/styleEditor/style
             if (style[itemSelector] && style[itemSelector]['font-size']) {
                 itemFontSize = parseInt(style[itemSelector]['font-size'], 10);
                 $input.val(itemFontSize);
-            } if (style[itemSelectorOld] && style[itemSelectorOld]['font-size']) {
+            } else if (style[itemSelectorOld] && style[itemSelectorOld]['font-size']) {
                 itemFontSize = parseInt(style[itemSelectorOld]['font-size'], 10);
                 $input.val(itemFontSize);
             } else {


### PR DESCRIPTION
**RELATED TO:**
AUT: 2639 [https://oat-sa.atlassian.net/browse/AUT-2639](url)
AUT-2653 [https://oat-sa.atlassian.net/browse/AUT-2653](url)
AUT-2654 [https://oat-sa.atlassian.net/browse/AUT-2654](url)

**STEPS TO TEST:**
1. Create  Passage add texto and an image
2. change the background color, or any other colors in color picker
3. Click on image

**CURRENT RESULT:**
- Background color doesn't apply to all background but seems broken

- When image active, bin button inherits styles: background color and padding, resutling on a bigger size.

**EXPECTED RESULT:**
- Background color is uniform and affect all text  background.

- When focusing on image, bin icon stays standard color and size
![image](https://user-images.githubusercontent.com/60346520/192306079-1b9aea9f-101a-42a8-8a85-d7e15ba48d8f.png)

