### PR TITLE
feat: support new ui test preview

### DIFF
--- a/views/js/richPassage/helpers.js
+++ b/views/js/richPassage/helpers.js
@@ -17,12 +17,13 @@
  */
 
 define([
+    'jquery',
     'lodash',
     'uri',
     'util/url',
     'core/dataProvider/request',
     'taoMediaManager/qtiCreator/helper/formatStyles'
-], function (_, uri, urlUtil, request, formatStyles) {
+], function ($, _, uri, urlUtil, request, formatStyles) {
     'use strict';
 
     /**
@@ -107,6 +108,8 @@ define([
                                         qtiClass: 'stylesheet',
                                         attributes: {
                                             href: stylesheetHref,
+                                            includeHref: passageHref,
+                                            includeSerial: elem.serial,
                                             media: 'all',
                                             title: '',
                                             type: 'text/css',
@@ -114,6 +117,7 @@ define([
                                         },
                                         serial
                                     };
+                                    elem.stylesheets = {[serial]: stylesheetHref};
                                 });
                             })
                             .catch()

--- a/views/js/richPassage/helpers.js
+++ b/views/js/richPassage/helpers.js
@@ -108,8 +108,6 @@ define([
                                         qtiClass: 'stylesheet',
                                         attributes: {
                                             href: stylesheetHref,
-                                            includeHref: passageHref,
-                                            includeSerial: elem.serial,
                                             media: 'all',
                                             title: '',
                                             type: 'text/css',
@@ -117,7 +115,12 @@ define([
                                         },
                                         serial
                                     };
-                                    elem.stylesheets = {[serial]: stylesheetHref};
+                                    if (stylesheet.name !== 'tao-user-styles.css') {
+                                        // only for uploaded stylesheets
+                                        itemData.content.data.stylesheets[serial].attributes.includeHref = passageHref;
+                                        itemData.content.data.stylesheets[serial].attributes.includeSerial = elem.serial;
+                                        elem.stylesheets = {[serial]: stylesheetHref};
+                                    }
                                 });
                             })
                             .catch()


### PR DESCRIPTION
Related to :[ AUT-2560](https://oat-sa.atlassian.net/browse/AUT-2560)

According feature Scope passage style in Solar UI https://github.com/oat-sa/tao-deliver-fe/pull/521 need to add 

- a `stylesheets` property added to the x-include declaration, with a mapping between the serial and the CSS file
- a couple of properties `includeHref` and `includeSerial` added to the stylesheet declaration, referencing the passage