### PR TITLE
[Fix] Use children list from css files in accordance with the latest changes

### DIFF
--- a/model/sharedStimulus/service/CopyService.php
+++ b/model/sharedStimulus/service/CopyService.php
@@ -111,14 +111,14 @@ class CopyService
 
         $newCssFiles = [];
 
-        foreach ($cssFiles as $baseName) {
+        foreach ($cssFiles['children'] as $child) {
             $newCssFiles[] = $this->tempFileWriter->writeFile(
                 self::NAMESPACE_TEMP_FILES,
-                $baseName,
+                $child['name'],
                 $this->stylesheetRepository->read(
                     implode(
                         DIRECTORY_SEPARATOR,
-                        [$cssPath , StoreService::CSS_DIR_NAME, $baseName]
+                        [$cssPath , StoreService::CSS_DIR_NAME, $child['name']]
                     )
                 )
             );

--- a/test/unit/model/sharedStimulus/service/CopyServiceTest.php
+++ b/test/unit/model/sharedStimulus/service/CopyServiceTest.php
@@ -230,13 +230,34 @@ class CopyServiceTest extends TestCase
             ->expects($this->once())
             ->method('getList')
             ->willReturnCallback(function (ListStylesheets $dto) {
-                if ($dto->getUri() != 'http://example.com/resource1') {
+                if ($dto->getUri() !== 'http://example.com/resource1') {
                     $this->fail(
                         "Unexpected call to getList for URI {$dto->getUri()}"
                     );
                 }
             })
-            ->willReturn(['cssBasename1', 'cssBasename2']);
+            ->willReturn([
+                'path' => DIRECTORY_SEPARATOR,
+                'label' => 'Passage stylesheets',
+                'childrenLimit' => 100,
+                'total' => 2,
+                'children' => [
+                    [
+                        'name' => 'cssBasename1',
+                        'uri' => DIRECTORY_SEPARATOR . 'cssBasename1',
+                        'mime' => 'text/css',
+                        'filePath' => DIRECTORY_SEPARATOR . 'cssBasename1',
+                        'size' => 100,
+                    ],
+                    [
+                        'name' => 'cssBasename2',
+                        'uri' => DIRECTORY_SEPARATOR . 'cssBasename2',
+                        'mime' => 'text/css',
+                        'filePath' => DIRECTORY_SEPARATOR . 'cssBasename2',
+                        'size' => 200,
+                    ],
+                ],
+            ]);
 
         $this->tempFileWriter
             ->expects($this->exactly(2))


### PR DESCRIPTION
# Task
[AUT-2687](https://oat-sa.atlassian.net/browse/AUT-2687)

# PHP 8 migration
[ADF-1097](https://oat-sa.atlassian.net/browse/ADF-1097)
[ADF-1087](https://oat-sa.atlassian.net/browse/ADF-1087)
[ADF-1105](https://oat-sa.atlassian.net/browse/ADF-1105)

# Changes
* Use `children` sublist to get all necessary CSS files
* Use `name` list-value to get the basename

This change is needed because of a previous change in the return value format of `ListStylesheetsService::getList()` ([here](https://github.com/oat-sa/extension-tao-mediamanager/blob/develop/model/sharedStimulus/css/service/ListStylesheetsService.php#L31))