### PR TITLE
Fix/aut 2694/hide styles with no class name

### DIFF
--- a/views/js/previewer/proxy/qtiSharedStimulusItem.js
+++ b/views/js/previewer/proxy/qtiSharedStimulusItem.js
@@ -115,7 +115,7 @@ define([
                                 media: 'all',
                                 title: '',
                                 type: 'text/css',
-                                onload: (e => formatStyles.handleStylesheetLoad(e, stylesheet))
+                                onload: (e => formatStyles.handleStylesheetLoad(e))
                             },
                             serial,
                             getComposingElements: () => ({})

--- a/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
+++ b/views/js/qtiCreator/component/tpl/sharedStimulusAuthoring.tpl
@@ -75,28 +75,28 @@
                                         <button class="icon-eraser reset-button" data-value="background-color"
                                             aria-label="{{__ 'Remove custom background color'}}"></button>
                                         <button class="color-trigger" id="initial-bg" data-value="background-color"
-                                            data-target="body div.qti-item .mainClass" data-additional="padding:20px"></button>
+                                            data-target="body div.qti-item" data-additional="padding:20px"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Text color'}}</label>
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom text color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="color"
-                                              data-target="body div.qti-item .mainClass"></button>
+                                              data-target="body div.qti-item"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Border color'}}</label>
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom border color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="border-color"
-                                              data-target="body div.qti-item .mainClass" data-additional="border-width:4px;border-style:solid;padding:20px"></button>
+                                              data-target="body div.qti-item" data-additional="border-width:4px;border-style:solid;padding:20px"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Table headings'}}</label>
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom background color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="background-color"
-                                              data-target="body div.qti-item .mainClass table th"></button>
+                                              data-target="body div.qti-item table th"></button>
                                     </div>
                                 </div>
                             </div>
@@ -108,7 +108,7 @@
 
                             <div class="reset-group">
                                 <select
-                                    data-target="body div.qti-item .mainClass *"
+                                    data-target="body div.qti-item *"
                                     id="item-editor-font-selector"
                                     data-has-search="false"
                                     data-placeholder="{{__ 'Default'}}"
@@ -122,7 +122,7 @@
                         <div class="panel">
                             <div>{{__ 'Font size'}}</div>
                             <div class="reset-group">
-                                <span id="item-editor-font-size-changer" data-target="body div.qti-item .mainClass *">
+                                <span id="item-editor-font-size-changer" data-target="body div.qti-item *">
                                     <button data-action="reduce" aria-label="{{__ 'Reduce font size'}}"
                                         class="icon-smaller"></button>
                                     <button data-action="enlarge" aria-label="{{__ 'Enlarge font size'}}"
@@ -165,28 +165,28 @@
                                         <button class="icon-eraser reset-button" data-value="background-color"
                                               aria-label="{{__ 'Remove custom background color'}}"></button>
                                         <button class="color-trigger" id="initial-bg" data-value="background-color"
-                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass" data-additional="padding:20px;margin-bottom: 0;"></button>
+                                              data-target="body div.qti-item .custom-text-box.hashClass" data-additional="padding:20px;margin-bottom: 0;"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Text color'}}</label>
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom text color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="color"
-                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass"></button>
+                                              data-target="body div.qti-item .custom-text-box.hashClass"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Border color'}}</label>
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom border color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="border-color"
-                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass" data-additional="border-width:4px;border-style:solid;padding:20px"></button>
+                                              data-target="body div.qti-item .custom-text-box.hashClass" data-additional="border-width:4px;border-style:solid;padding:20px"></button>
                                     </div>
                                     <div class="clearfix">
                                         <label for="initial-color" class="truncate">{{__ 'Table headings'}}</label>
                                         <button class="icon-eraser reset-button" data-value="color"
                                               aria-label="{{__ 'Remove custom background color'}}"></button>
                                         <button class="color-trigger" id="initial-color" data-value="background-color"
-                                              data-target="body div.qti-item .mainClass .custom-text-box.hashClass table th"></button>
+                                              data-target="body div.qti-item .custom-text-box.hashClass table th"></button>
                                     </div>
                                 </div>
                             </div>
@@ -198,7 +198,7 @@
 
                             <div class="reset-group">
                                 <select
-                                    data-target="body div.qti-item .mainClass .custom-text-box.hashClass *"
+                                    data-target="body div.qti-item .custom-text-box.hashClass *"
                                     id="item-editor-font-selector"
                                     data-has-search="false"
                                     data-placeholder="{{__ 'Default'}}"
@@ -212,7 +212,7 @@
                         <div class="panel">
                             <div>{{__ 'Font size'}}</div>
                             <div class="reset-group">
-                                        <span id="item-editor-font-size-changer" data-target="body div.qti-item .mainClass .custom-text-box.hashClass *">
+                                        <span id="item-editor-font-size-changer" data-target="body div.qti-item .custom-text-box.hashClass *">
                                             <button data-action="reduce" aria-label="{{__ 'Reduce font size'}}"
                                                class="icon-smaller"></button>
                                             <button data-action="enlarge" aria-label="{{__ 'Enlarge font size'}}"

--- a/views/js/qtiCreator/editor/styleEditor/colorSelector.js
+++ b/views/js/qtiCreator/editor/styleEditor/colorSelector.js
@@ -71,12 +71,10 @@ define([
         const setTriggerColor = function () {
             colorTriggers.each(function () {
                 const $trigger = $(this);
-                let target = styleEditor.replaceMainClass($trigger.data('target'));
-                target = styleEditor.replaceHashClass(target);
+                let target = styleEditor.replaceHashClass($trigger.data('target'));
                 const style = styleEditor.getStyle() || {};
                 let value;
                 const targetOld = target.replace(' *', ''); // previous version was without *
-                // elements have a color from usage of style editor
                 if (style[target] && style[target][$trigger.data('value')]) {
                     value = style[target][$trigger.data('value')].replace(' !important', '');
                     $trigger.css('background-color', value);
@@ -99,8 +97,7 @@ define([
         const collectCommonAdditionalStyles = function () {
             colorTriggers.each(function () {
                 const $trigger = $(this);
-                let target = styleEditor.replaceMainClass($trigger.data('target'));
-                target = styleEditor.replaceHashClass(target);
+                let target = styleEditor.replaceHashClass($trigger.data('target'));
                 const value = $trigger.data('value');
                 const styles = additionalStylesToObject($trigger.data('additional'));
                 Object.keys(styles).forEach(key => {
@@ -180,8 +177,7 @@ define([
         resetButtons.off('click').on('click', function () {
             const $this = $(this);
             const $colorTrigger = $this.parent().find('.color-trigger');
-            let target = styleEditor.replaceMainClass($colorTrigger.data('target'));
-            target = styleEditor.replaceHashClass(target);
+            let target = styleEditor.replaceHashClass($colorTrigger.data('target'));
             const value = $colorTrigger.data('value');
             const additional = $colorTrigger.data('additional');
             styleEditor.apply(target, value);

--- a/views/js/qtiCreator/editor/styleEditor/fontSelector.js
+++ b/views/js/qtiCreator/editor/styleEditor/fontSelector.js
@@ -47,8 +47,7 @@ define([
     const fontSelector = function ($container) {
         const selector = 'select#item-editor-font-selector',
             $selector = $container.find(selector);
-        let target = styleEditor.replaceMainClass($selector.data('target'));
-        target = styleEditor.replaceHashClass(target);
+        let target = styleEditor.replaceHashClass($selector.data('target'));
         let normalize = function (font) {
                 return font.replace(/"/g, "'").replace(/, /g, ',');
             },

--- a/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
+++ b/views/js/qtiCreator/editor/styleEditor/fontSizeChanger.js
@@ -31,7 +31,7 @@ define(['jquery', 'lodash', 'taoMediaManager/qtiCreator/editor/styleEditor/style
      */
     const fontSizeChanger = function ($container) {
         const $fontSizeChanger = $container.find('#item-editor-font-size-changer');
-        let itemSelector = styleEditor.replaceMainClass($fontSizeChanger.data('target'));
+        let itemSelector = styleEditor.replaceHashClass($fontSizeChanger.data('target'));
         itemSelector = styleEditor.replaceHashClass(itemSelector);
         const figcaptionSelector = `${itemSelector} figure figcaption`;
         const $resetBtn = $fontSizeChanger.parents('.reset-group').find('[data-role="font-size-reset"]');

--- a/views/js/qtiCreator/editor/styleEditor/styleEditor.js
+++ b/views/js/qtiCreator/editor/styleEditor/styleEditor.js
@@ -378,7 +378,7 @@ define([
                 _link.attr('href');
             const _sep = _href.indexOf('?') > -1 ? '&' : '?';
             _link.attr('href', _href + _sep + new Date().getTime().toString());
-            _link[0].onload = e => formatStyles.handleStylesheetLoad(e, stylesheet);
+            _link[0].onload = e => formatStyles.handleStylesheetLoad(e);
             return _link;
         })();
 

--- a/views/js/qtiCreator/helper/formatStyles.js
+++ b/views/js/qtiCreator/helper/formatStyles.js
@@ -41,6 +41,8 @@ define([
                     const assetClassName = asset.children[0].className.match(/[\w-]*tao-[\w-]*/g) || asset.children[1].className.match(/[\w-]*tao-[\w-]*/g);
                     if (assetClassName) {
                         _formatStyles(linkTag.sheet, assetClassName[0]);
+                    } else {
+                        _hideStyles(linkTag.sheet);
                     }
                 });
                 return;
@@ -72,6 +74,23 @@ define([
                 return;
             }
         }
+    }
+
+    function _hideStyles(linkTag) {
+        /**
+         * @type {CSSRuleList}
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSRuleList
+         */
+        const { cssRules } = linkTag || {};
+        const CSSStyleSheet = linkTag || {};
+
+        if (cssRules) {
+            Object.values(cssRules).map((index, rule) => {
+                CSSStyleSheet.deleteRule(index);
+            });
+        }
+
+        return;
     }
 
     function _formatStyles(linkTag, className) {

--- a/views/js/qtiCreator/helper/formatStyles.js
+++ b/views/js/qtiCreator/helper/formatStyles.js
@@ -20,11 +20,7 @@ define([
 ], function ($) {
     'use strict';
 
-    function handleStylesheetLoad(e, stylesheet) {
-        if (stylesheet && stylesheet.name === 'tao-user-styles.css') {
-            return false;
-        }
-
+    function handleStylesheetLoad(e) {
         // get cssRules from owner link tag, referenced in load event
         const path = e && e.composedPath && e.composedPath();
         const linkTag = path[0];

--- a/views/js/qtiCreator/helper/sharedStimulusLoader.js
+++ b/views/js/qtiCreator/helper/sharedStimulusLoader.js
@@ -63,7 +63,7 @@ define([
                                         media: 'all',
                                         title: stylesheet.name,
                                         type: 'text/css',
-                                        onload: (e => formatStyles.handleStylesheetLoad(e, stylesheet))
+                                        onload: (e => formatStyles.handleStylesheetLoad(e))
                                     },
                                     serial,
                                     getComposingElements: () => ({})

--- a/views/js/richPassage/helpers.js
+++ b/views/js/richPassage/helpers.js
@@ -115,12 +115,9 @@ define([
                                         },
                                         serial
                                     };
-                                    if (stylesheet.name !== 'tao-user-styles.css') {
-                                        // only for uploaded stylesheets
-                                        itemData.content.data.stylesheets[serial].attributes.includeHref = passageHref;
-                                        itemData.content.data.stylesheets[serial].attributes.includeSerial = elem.serial;
-                                        elem.stylesheets = {[serial]: stylesheetHref};
-                                    }
+                                    itemData.content.data.stylesheets[serial].attributes.includeHref = passageHref;
+                                    itemData.content.data.stylesheets[serial].attributes.includeSerial = elem.serial;
+                                    elem.stylesheets = {[serial]: stylesheetHref};
                                 });
                             })
                             .catch()

--- a/views/js/richPassage/helpers.js
+++ b/views/js/richPassage/helpers.js
@@ -111,7 +111,7 @@ define([
                                             media: 'all',
                                             title: '',
                                             type: 'text/css',
-                                            onload: (e => formatStyles.handleStylesheetLoad(e, stylesheet))
+                                            onload: (e => formatStyles.handleStylesheetLoad(e))
                                         },
                                         serial
                                     };

--- a/views/js/richPassage/xincludeRendererAddStyles.js
+++ b/views/js/richPassage/xincludeRendererAddStyles.js
@@ -46,7 +46,7 @@ define([
                             'data-serial': passageUri
                         });
                         if (!preview) {
-                            styleElem[0].onload = (e => formatStyles.handleStylesheetLoad(e, stylesheet));
+                            styleElem[0].onload = (e => formatStyles.handleStylesheetLoad(e));
                             styleElem[0].dataset['serial'] = serial;
                         }
                         head.append(styleElem);


### PR DESCRIPTION
**Related to:** 
[AUT-2725](https://oat-sa.atlassian.net/browse/AUT-2725)
[TR-4800](https://oat-sa.atlassian.net/browse/TR-4800)

**Description:**
- Remove Asset mainClass for the `tao-user-styles`
- Apply CSS format to `tao-user-styles`
- Hide CSS styles from when there is no content on the Asset

**How to check:**

- Create an Asset with no data. Save it. Upload a CSS file. Go out and edit again. Check the CSS is not applied to the Asset.
- Create an Asset with CSS files and Passage styles. Import on Item and create test. Check Previews and solar Delivery.