### PR TITLE
fix: remove mainClass from old selectors

### DIFF
--- a/views/js/qtiCreator/editor/styleEditor/styleEditor.js
+++ b/views/js/qtiCreator/editor/styleEditor/styleEditor.js
@@ -474,7 +474,16 @@ define([
 
         request(_getUri('load'), _.extend({}, itemConfig, { stylesheetUri: href })).then(function (_style) {
             // copy style to global style
-            style = _style;
+            style = {};
+
+            Object.keys(_style).forEach(key => {
+                if (!key.includes(mainClass)) {
+                    style[key] = _style[key];
+                } else {
+                    const selectorWithoutMainClass = key.replace(`.${mainClass}`, '').trim();
+                    style[selectorWithoutMainClass] = _style[key];
+                }
+            })
 
             // apply rules
             create();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2637

Fix old passages on save. To have styles in item and tests preview, delivery