### PR TITLE
fix: remove extra space on remove the mainClass

### DIFF
--- a/views/js/qtiCreator/editor/styleEditor/styleEditor.js
+++ b/views/js/qtiCreator/editor/styleEditor/styleEditor.js
@@ -480,7 +480,7 @@ define([
                 if (!key.includes(mainClass)) {
                     style[key] = _style[key];
                 } else {
-                    const selectorWithoutMainClass = key.replace(`.${mainClass}`, '').trim();
+                    const selectorWithoutMainClass = key.replace(` .${mainClass}`, '').trim();
                     style[selectorWithoutMainClass] = _style[key];
                 }
             })


### PR DESCRIPTION
Related to https://github.com/oat-sa/extension-tao-mediamanager/pull/441

Remove extra space on the replace action to avoid keeping 2 blank spaces.