### PR TITLE
fix: return promise, used in tooltip

### DIFF
--- a/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
+++ b/views/js/qtiCreator/editor/ckEditor/htmlEditor.js
@@ -572,7 +572,7 @@ define([
          * @returns {undefined}
          */
         buildEditor: function ($container, editorOptions) {
-            languages
+            return languages
                 .getList()
                 .then(languages.useCKEFormatting)
                 .then(languagesData => {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-10644

Regression after https://github.com/oat-sa/extension-tao-itemqti/pull/2170/files#diff-8812e9f82994923534c4ea77dfd8c8c3637d071f859a5eaa6ef02baae2c51664

Here we expecting Promise https://github.com/oat-sa/extension-tao-itemqti/blob/d7ec12874281dadaf19e2fed43867af6ecb93a5e/views/js/qtiCreator/widgets/static/tooltip/components/editorField.js#L66-L92
