### PR TITLE
chore: add missing dependencies for ACL strategy copy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/lib-generis-search": "2.1.2",
-        "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
-        "oat-sa/extension-tao-item": "dev-feat/RFE-530/integration-branch as 12.0",
+        "oat-sa/generis": ">=15.24",
+        "oat-sa/tao-core": ">=52.1",
+        "oat-sa/extension-tao-item": ">=11.3",
         "oat-sa/extension-tao-itemqti": ">=29.14.5",
-        "oat-sa/extension-tao-test": "dev-feat/RFE-530/integration-branch as 16.0",
+        "oat-sa/extension-tao-test": ">=15.16",
         "oat-sa/extension-tao-testqti-previewer": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/lib-generis-search": "2.1.2",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": ">=50.27.0",
-        "oat-sa/extension-tao-item": ">=11.13.4",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
+        "oat-sa/extension-tao-item": "dev-feat/RFE-530/integration-branch as 12.0",
         "oat-sa/extension-tao-itemqti": ">=29.14.5",
-        "oat-sa/extension-tao-test": ">=15.0.0",
+        "oat-sa/extension-tao-test": "dev-feat/RFE-530/integration-branch as 16.0",
         "oat-sa/extension-tao-testqti-previewer": "*"
     },
     "autoload": {

--- a/model/classes/Copier/AssetClassCopier.php
+++ b/model/classes/Copier/AssetClassCopier.php
@@ -76,7 +76,7 @@ class AssetClassCopier implements ClassCopierInterface, ResourceTransferInterfac
         if (!$this->mediaClassSpecification->isSatisfiedBy($class)) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'Selected class (%s) is not supported because it is not part of the media assets root class (%s).',
+                    'Class (%s) is not supported. Only classes from (%s) are supported',
                     $class->getUri(),
                     TaoMediaOntology::CLASS_URI_MEDIA_ROOT
                 )

--- a/model/classes/Copier/AssetClassCopier.php
+++ b/model/classes/Copier/AssetClassCopier.php
@@ -22,44 +22,53 @@ declare(strict_types=1);
 
 namespace oat\taoMediaManager\model\classes\Copier;
 
+use oat\generis\model\data\Ontology;
+use oat\tao\model\resources\Command\ResourceTransferCommand;
 use oat\tao\model\resources\Contract\ClassCopierInterface;
-use oat\tao\model\resources\Contract\ClassPropertyCopierInterface;
-use oat\tao\model\resources\Contract\RootClassesListServiceInterface;
-use oat\tao\model\resources\Service\ClassPropertyCopier;
+use oat\tao\model\resources\Contract\ResourceTransferInterface;
+use oat\tao\model\resources\ResourceTransferResult;
 use oat\tao\model\Specification\ClassSpecificationInterface;
 use oat\taoMediaManager\model\TaoMediaOntology;
 use core_kernel_classes_Class;
 use InvalidArgumentException;
 
-class AssetClassCopier implements ClassCopierInterface
+class AssetClassCopier implements ClassCopierInterface, ResourceTransferInterface
 {
-    /** @var RootClassesListServiceInterface */
-    private $rootClassesListService;
-
-    /** @var ClassSpecificationInterface */
-    private $mediaClassSpecification;
-
-    /** @var ClassCopierInterface */
-    private $taoClassCopier;
+    private ClassSpecificationInterface $mediaClassSpecification;
+    private ResourceTransferInterface $taoClassCopier;
+    private Ontology $ontology;
 
     public function __construct(
-        RootClassesListServiceInterface $rootClassesListService,
         ClassSpecificationInterface $mediaClassSpecification,
-        ClassCopierInterface $taoClassCopier
+        ResourceTransferInterface $taoClassCopier,
+        Ontology $ontology
     ) {
-        $this->rootClassesListService = $rootClassesListService;
         $this->mediaClassSpecification = $mediaClassSpecification;
         $this->taoClassCopier = $taoClassCopier;
+        $this->ontology = $ontology;
+    }
+
+    public function transfer(ResourceTransferCommand $command): ResourceTransferResult
+    {
+        $this->assertInAssetsRootClass($this->ontology->getClass($command->getFrom()));
+
+        return $this->taoClassCopier->transfer($command);
     }
 
     public function copy(
         core_kernel_classes_Class $class,
         core_kernel_classes_Class $destinationClass
     ): core_kernel_classes_Class {
-        $this->assertInAssetsRootClass($class);
-        $this->assertInAssetsRootClass($destinationClass);
+        $result = $this->transfer(
+            new ResourceTransferCommand(
+                $class->getUri(),
+                $destinationClass->getUri(),
+                ResourceTransferCommand::ACL_KEEP_ORIGINAL,
+                ResourceTransferCommand::TRANSFER_MODE_COPY
+            )
+        );
 
-        return $this->taoClassCopier->copy($class, $destinationClass);
+        return $this->ontology->getClass($result->getDestination());
     }
 
     private function assertInAssetsRootClass(core_kernel_classes_Class $class): void

--- a/model/classes/ServiceProvider/MediaServiceProvider.php
+++ b/model/classes/ServiceProvider/MediaServiceProvider.php
@@ -127,6 +127,7 @@ class MediaServiceProvider implements ContainerServiceProviderInterface
             ->args(
                 [
                     service(AssetMetadataCopier::class),
+                    service(Ontology::SERVICE_ID)
                 ]
             )
             ->call(

--- a/model/classes/ServiceProvider/MediaServiceProvider.php
+++ b/model/classes/ServiceProvider/MediaServiceProvider.php
@@ -138,7 +138,7 @@ class MediaServiceProvider implements ContainerServiceProviderInterface
             ->call(
                 'withPermissionCopiers',
                 [
-                    tagged_iterator('tao.copier.permissions.instance.assets'),
+                    tagged_iterator('tao.copier.permissions'),
                 ]
             );
 
@@ -157,7 +157,7 @@ class MediaServiceProvider implements ContainerServiceProviderInterface
             ->call(
                 'withPermissionCopiers',
                 [
-                    tagged_iterator('tao.copier.permissions.class.assets'),
+                    tagged_iterator('tao.copier.permissions'),
                 ]
             );
 

--- a/model/classes/ServiceProvider/MediaServiceProvider.php
+++ b/model/classes/ServiceProvider/MediaServiceProvider.php
@@ -166,9 +166,9 @@ class MediaServiceProvider implements ContainerServiceProviderInterface
             ->share(false)
             ->args(
                 [
-                    service(RootClassesListService::class),
                     service(MediaClassSpecification::class),
                     service(TaoClassCopier::class . '::ASSETS'),
+                    service(Ontology::SERVICE_ID),
                 ]
             );
 

--- a/model/classes/ServiceProvider/MediaServiceProvider.php
+++ b/model/classes/ServiceProvider/MediaServiceProvider.php
@@ -54,6 +54,9 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
+/**
+ * @codeCoverageIgnore
+ */
 class MediaServiceProvider implements ContainerServiceProviderInterface
 {
     public function __invoke(ContainerConfigurator $configurator): void

--- a/model/classes/ServiceProvider/MediaServiceProvider.php
+++ b/model/classes/ServiceProvider/MediaServiceProvider.php
@@ -29,11 +29,10 @@ use oat\tao\model\accessControl\PermissionChecker;
 use oat\tao\model\resources\Service\ClassCopierProxy;
 use oat\tao\model\resources\Service\ClassMetadataCopier;
 use oat\tao\model\resources\Service\ClassMetadataMapper;
-use oat\tao\model\resources\Service\ClassPropertyCopier;
 use oat\tao\model\resources\Service\InstanceCopier;
+use oat\tao\model\resources\Service\InstanceCopierProxy;
 use oat\tao\model\resources\Service\InstanceMetadataCopier;
 use oat\tao\model\resources\Service\RootClassesListService;
-use oat\taoItems\model\Copier\ClassCopier;
 use oat\tao\model\resources\Service\ClassCopier as TaoClassCopier;
 use oat\taoMediaManager\model\accessControl\MediaPermissionService;
 use oat\taoMediaManager\model\classes\Copier\AssetClassCopier;
@@ -180,6 +179,16 @@ class MediaServiceProvider implements ContainerServiceProviderInterface
                 [
                     TaoMediaOntology::CLASS_URI_MEDIA_ROOT,
                     service(AssetClassCopier::class),
+                ]
+            );
+
+        $services
+            ->get(InstanceCopierProxy::class)
+            ->call(
+                'addInstanceCopier',
+                [
+                    TaoMediaOntology::CLASS_URI_MEDIA_ROOT,
+                    service(InstanceCopier::class . '::ASSETS'),
                 ]
             );
     }

--- a/model/classes/ServiceProvider/MediaServiceProvider.php
+++ b/model/classes/ServiceProvider/MediaServiceProvider.php
@@ -151,6 +151,7 @@ class MediaServiceProvider implements ContainerServiceProviderInterface
                     service(ClassMetadataCopier::class),
                     service(InstanceCopier::class . '::ASSETS'),
                     service(ClassMetadataMapper::class),
+                    service(Ontology::SERVICE_ID),
                 ]
             )
             ->call(

--- a/test/unit/model/classes/Copier/AssetClassCopierTest.php
+++ b/test/unit/model/classes/Copier/AssetClassCopierTest.php
@@ -15,34 +15,27 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
  */
 
 declare(strict_types=1);
 
 namespace oat\taoMediaManager\test\unit\model;
 
-use oat\tao\model\resources\Contract\ClassPropertyCopierInterface;
-use oat\tao\model\resources\Contract\RootClassesListServiceInterface;
+use oat\generis\model\data\Ontology;
+use oat\tao\model\resources\Command\ResourceTransferCommand;
+use oat\tao\model\resources\Contract\ResourceTransferInterface;
+use oat\tao\model\resources\ResourceTransferResult;
 use oat\taoMediaManager\model\classes\Copier\AssetClassCopier;
 use oat\taoMediaManager\model\Specification\MediaClassSpecification;
-use oat\taoMediaManager\model\TaoMediaOntology;
-use oat\taoItems\model\Copier\ItemClassCopier;
-use oat\tao\model\resources\Contract\ClassCopierInterface;
 use core_kernel_classes_Class;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
 
 class AssetClassCopierTest extends TestCase
 {
-    private const ASSET_ROOT_CLASS_URI = TaoMediaOntology::CLASS_URI_MEDIA_ROOT;
-
-    private const ERRMSG_NOT_IN_ASSETS_ROOT =
-        'Selected class (%s) is not supported because it is not part of the media assets root class (%s).';
-
-    /** @var ClassCopierInterface|MockObject */
+    /** @var ResourceTransferInterface|MockObject */
     private $taoClassCopier;
 
     /** @var core_kernel_classes_Class|MockObject */
@@ -51,18 +44,18 @@ class AssetClassCopierTest extends TestCase
     /** @var core_kernel_classes_Class|MockObject */
     private $target;
 
-    /** @var ItemClassCopier */
-    private $sut;
+    /** @var Ontology|MockObject */
+    private $ontology;
+    private AssetClassCopier $sut;
 
     protected function setUp(): void
     {
-        $this->taoClassCopier = $this->createMock(ClassCopierInterface::class);
+        $this->taoClassCopier = $this->createMock(ResourceTransferInterface::class);
         $this->source = $this->createMock(core_kernel_classes_Class::class);
         $this->target = $this->createMock(core_kernel_classes_Class::class);
+        $this->ontology = $this->createMock(Ontology::class);
 
-        $mediaClassSpecification = $this->createMock(
-            MediaClassSpecification::class
-        );
+        $mediaClassSpecification = $this->createMock(MediaClassSpecification::class);
         $mediaClassSpecification
             ->method('isSatisfiedBy')
             ->willReturnCallback(function (core_kernel_classes_Class $class) {
@@ -75,94 +68,64 @@ class AssetClassCopierTest extends TestCase
                         'http://asset.root/2/1',
                         'http://asset.root/1/c1',
                         'http://asset.root/1/c2',
-                    ]
+                    ],
+                    true
                 );
             });
 
-        $this->sut = new AssetClassCopier(
-            $this->getRootClassesListServiceMock(),
-            $mediaClassSpecification,
-            $this->taoClassCopier
-        );
+        $this->sut = new AssetClassCopier($mediaClassSpecification, $this->taoClassCopier, $this->ontology);
     }
 
-    /**
-     * @dataProvider copyInvalidClassTypesDataProvider
-     */
-    public function testCopyInvalidClassType(
-        string $sourceUri,
-        string $targetUri,
-        string $unsupportedClass
-    ): void {
+    public function testTransferInvalidClassType(): void
+    {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            sprintf(
-                self::ERRMSG_NOT_IN_ASSETS_ROOT,
-                $unsupportedClass,
-                self::ASSET_ROOT_CLASS_URI
-            )
+            'Class (unsupportedUri) is not supported. Only classes from ' .
+            '(http://www.tao.lu/Ontologies/TAOMedia.rdf#Media)'
         );
 
-        $this->source->method('getUri')->willReturn($sourceUri);
-        $this->target->method('getUri')->willReturn($targetUri);
+        $this->source->method('getUri')->willReturn('unsupportedUri');
 
-        $this->sut->copy($this->source, $this->target);
+        $command = new ResourceTransferCommand(
+            'unsupportedUri',
+            'unsupportedUri',
+            ResourceTransferCommand::ACL_KEEP_ORIGINAL,
+            ResourceTransferCommand::TRANSFER_MODE_COPY
+        );
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getClass')
+            ->willReturn($this->source);
+
+        $this->sut->transfer($command);
     }
 
-    public function copyInvalidClassTypesDataProvider(): array
+    public function testTransfer(): void
     {
-        return [
-            'Copy from a non-assets class type' => [
-                'sourceUri' => 'http://test.root/1',
-                'targetUri' => 'http://asset.root/2',
-                'unsupportedClass' => 'http://test.root/1',
-            ],
-            'Copy to a non-assets class type' => [
-                'sourceUri' => 'http://asset.root/1',
-                'targetUri' => 'http://item.root/2',
-                'unsupportedClass' => 'http://item.root/2',
-            ],
-        ];
-    }
-
-    public function testCopy(): void
-    {
-        // getUri used by the mediaClassSpecification mock callback
-        //
         $this->source->method('getUri')->willReturn('http://asset.root/1/c1');
         $this->target->method('getUri')->willReturn('http://asset.root/1/c2');
 
+        $command = new ResourceTransferCommand(
+            'http://asset.root/1/c1',
+            'http://asset.root/1/c2',
+            ResourceTransferCommand::ACL_KEEP_ORIGINAL,
+            ResourceTransferCommand::TRANSFER_MODE_COPY
+        );
+
+        $result = new ResourceTransferResult('destinationUri');
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getClass')
+            ->willReturn($this->source);
+
         $this->taoClassCopier
             ->expects($this->once())
-            ->method('copy')
-            ->with($this->source, $this->target)
-            ->willReturnArgument(1);
+            ->method('transfer')
+            ->with($command)
+            ->willReturn($result);
 
-        $this->assertSame(
-            $this->target,
-            $this->sut->copy($this->source, $this->target)
-        );
-    }
-
-    /**
-     * @return RootClassesListServiceInterface|MockObject
-     */
-    private function getRootClassesListServiceMock()
-    {
-        $classRoot1 = $this->createMock(core_kernel_classes_Class::class);
-        $classRoot1->method('getUri')->willReturn('http://asset.root/1');
-
-        $classRoot2 = $this->createMock(core_kernel_classes_Class::class);
-        $classRoot2->method('getUri')->willReturn('http://asset.root/2');
-
-        $rootClassesListService = $this->createMock(
-            RootClassesListServiceInterface::class
-        );
-
-        $rootClassesListService
-            ->method('list')
-            ->willReturn([$classRoot1, $classRoot2]);
-
-        return $rootClassesListService;
+        $this->assertSame($result, $this->sut->transfer($command));
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/RFE-530
https://oat-sa.atlassian.net/browse/ADF-1424
https://oat-sa.atlassian.net/browse/ADF-1425
https://oat-sa.atlassian.net/browse/ADF-1426
https://oat-sa.atlassian.net/browse/ADF-1427

# Goal

Add dynamic ACL strategy to `Move to` and `Copy to` features

# How to test

- Login to backoffice
- Play with the new ACL options for Items/Assets/Tests

# Related PRs

- https://github.com/oat-sa/tao-core/pull/3776
- https://github.com/oat-sa/extension-tao-item/pull/607
- https://github.com/oat-sa/extension-tao-test/pull/438
- https://github.com/oat-sa/extension-tao-dac-simple/pull/216
- https://github.com/oat-sa/generis/pull/1036