### PR TITLE
Feature/BSA-391/Allow to disable figure widgets

### DIFF
--- a/views/js/qtiCreator/widgets/static/figure/Widget.js
+++ b/views/js/qtiCreator/widgets/static/figure/Widget.js
@@ -13,22 +13,25 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2022 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2022-2023 (original work) Open Assessment Technologies SA ;
  *
  */
 define([
     'jquery',
     'lodash',
+    'context',
     'taoQtiItem/qtiCreator/widgets/static/Widget',
     'taoMediaManager/qtiCreator/widgets/static/figure/states/states',
     'taoQtiItem/qtiCreator/widgets/static/helpers/widget',
     'tpl!taoQtiItem/qtiCreator/tpl/toolbars/media',
     'taoQtiItem/qtiCreator/widgets/static/helpers/inline',
     'ui/mediaEditor/plugins/mediaAlignment/helper'
-], function ($, _, Widget, states, helper, toolbarTpl, inlineHelper, alignmentHelper) {
+], function ($, _, context, Widget, states, helper, toolbarTpl, inlineHelper, alignmentHelper) {
     'use strict';
 
     const FigureWidget = Widget.clone();
+
+    const DISABLE_FIGURE_WIDGET = context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'];
 
     FigureWidget.initCreator = function initCreator(options) {
         const figure = this.element;
@@ -61,7 +64,7 @@ define([
     };
 
     FigureWidget.buildContainer = function buildContainer() {
-        if (this.element.attr('showFigure')) {
+        if (DISABLE_FIGURE_WIDGET || this.element.attr('showFigure')) {
             // If it is aligned to left or right, it will have FigCaption and will need Figure tag
             helper.buildBlockContainer(this);
         } else {


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/BSA-391

Requires: 
 - [x] https://github.com/oat-sa/tao-core-ui-fe/pull/580
 - [x] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/389
 - [x] https://github.com/oat-sa/tao-core/pull/3935
 - [x] https://github.com/oat-sa/extension-tao-itemqti/pull/2428

### Summary

Manage a feature flag for disabling the figure widget.

### Details

Some customers rely on the block positioning of the figures for aligning images in columns. The figure widget sets them to inline positioning, hence the need to have a feature flag for disabling it. The other possibility is to roll back the feature, but this is less handy.

The feature can be disabled thanks to the feature flag `FEATURE_FLAG_DISABLE_FIGURE_WIDGET`.
The feature is enabled by default

### How to test

- have all dependencies (other PR) installed
- edit an item and place images on the canvas. Check the attached ticket for a sample item.
- turn the feature flag on and off, and see the differences

### Tidbit

To set and manage the feature flag, take a look at this [documentation](https://github.com/oat-sa/tao-core/blob/master/models/classes/featureFlag/README.md).

```
php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_DISABLE_FIGURE_WIDGET -v true
```