### PR TITLE
fix: Copy Service now store correct link to an asset file source

### DIFF
--- a/model/classes/Copier/AssetMetadataCopier.php
+++ b/model/classes/Copier/AssetMetadataCopier.php
@@ -28,11 +28,6 @@ use core_kernel_classes_Property;
 class AssetMetadataCopier implements InstanceMetadataCopierInterface
 {
     /**
-     * Base filename for the asset (i.e. 123456789abcdef123456.mp4)
-     */
-    private const PROPERTY_LINK = TaoMediaOntology::PROPERTY_LINK;
-
-    /**
      * MD5 hash of the file contents
      */
     private const PROPERTY_MD5 = TaoMediaOntology::PROPERTY_MD5;

--- a/model/classes/Copier/AssetMetadataCopier.php
+++ b/model/classes/Copier/AssetMetadataCopier.php
@@ -61,10 +61,6 @@ class AssetMetadataCopier implements InstanceMetadataCopierInterface
         $this->copyProperty($instance, $destinationInstance, self::PROPERTY_LANGUAGE);
         $this->copyProperty($instance, $destinationInstance, self::PROPERTY_MD5);
         $this->copyProperty($instance, $destinationInstance, self::PROPERTY_MIME);
-
-        // References the original file instead of creating a copy
-        //
-        $this->copyProperty($instance, $destinationInstance, self::PROPERTY_LINK);
     }
 
     private function copyProperty(

--- a/model/sharedStimulus/service/CopyService.php
+++ b/model/sharedStimulus/service/CopyService.php
@@ -32,6 +32,7 @@ use oat\taoMediaManager\model\sharedStimulus\css\service\ListStylesheetsService;
 use oat\taoMediaManager\model\sharedStimulus\dto\SharedStimulusInstanceData;
 use oat\taoMediaManager\model\sharedStimulus\SharedStimulus;
 use InvalidArgumentException;
+use oat\taoMediaManager\model\TaoMediaOntology;
 
 class CopyService
 {
@@ -86,14 +87,19 @@ class CopyService
         );
 
         $srcXmlPath = $this->fileSourceUnserializer->unserialize($source->link);
-
-        $this->sharedStimulusStoreService->storeStream(
+        $stimulusFilename = basename($source->link);
+        $dirname = $this->sharedStimulusStoreService->storeStream(
             $this->fileManagement->getFileStream($srcXmlPath)->detach(),
-            basename($source->link),
+            $stimulusFilename,
             $this->copyCSSFilesFrom($source)
         );
 
         $target = $this->ontology->getResource($command->getDestinationUri());
+
+        $target->setPropertyValue(
+            $target->getProperty(TaoMediaOntology::PROPERTY_LINK),
+            $dirname . DIRECTORY_SEPARATOR . $stimulusFilename
+        );
 
         return new SharedStimulus(
             $source->resourceUri,

--- a/test/unit/model/classes/Copier/AssetMetadataCopierTest.php
+++ b/test/unit/model/classes/Copier/AssetMetadataCopierTest.php
@@ -133,12 +133,11 @@ class AssetMetadataCopierTest extends TestCase
             );
 
         $this->target
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(2))
             ->method('setPropertyValue')
             ->withConsecutive(
                 [$this->propertyMD5, 'c38cd6d9c873bf072d9753d730f87ce'],
                 [$this->propertyMime, 'video/mp4'],
-                [$this->propertyLink, '123456789abcdef123456.mp4']
             );
 
         $this->target

--- a/test/unit/model/sharedStimulus/service/CopyServiceTest.php
+++ b/test/unit/model/sharedStimulus/service/CopyServiceTest.php
@@ -175,6 +175,12 @@ class CopyServiceTest extends TestCase
             ->method('getUri')
             ->willReturn('http://example.com/resource2');
 
+        $propertyMock = $this->createMock(core_kernel_classes_Property::class);
+        $targetResource
+            ->expects($this->once())
+            ->method('getProperty')
+            ->willReturn($propertyMock);
+
         $this->ontology
             ->expects($this->at(0))
             ->method('getResource')


### PR DESCRIPTION
When copy asset we will store in rdf link to a correct source file

How to test:
1. Create class and place asset with a content in that class
2. Create new empty class
3. Copy class with new Passage and choose destination to another class.
4. Make changes in copied resource
5. Observe original asset. Make sure no changes are visible.

https://github.com/oat-sa/extension-tao-mediamanager/assets/16231681/dd583ac5-9e54-4a75-b174-bb327840f31b

