### PR TITLE
feat: add possibility to copy a single asset

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -56,6 +56,9 @@
                     <action id="class-copy-to" name="Copy To" url="/taoMediaManager/MediaManager/copyClass" context="class" group="tree" binding="copyClassTo">
                         <icon id="icon-move-item"/>
                     </action>
+                    <action id="item-copy-to" name="Copy To" url="/taoMediaManager/MediaManager/copyInstance" context="instance" group="tree" binding="copyTo">
+                        <icon id="icon-copy"/>
+                    </action>
                     <action id="media-export" name="Export" url="/taoMediaManager/MediaExport/index" group="tree"
                             context="resource">
                         <icon id="icon-export"/>

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -54,7 +54,7 @@
                         <icon id="icon-move-item"/>
                     </action>
                     <action id="class-copy-to" name="Copy To" url="/taoMediaManager/MediaManager/copyClass" context="class" group="tree" binding="copyClassTo">
-                        <icon id="icon-move-item"/>
+                        <icon id="icon-copy"/>
                     </action>
                     <action id="item-copy-to" name="Copy To" url="/taoMediaManager/MediaManager/copyInstance" context="instance" group="tree" binding="copyTo">
                         <icon id="icon-copy"/>

--- a/migrations/Version202407181259241000_taoMediaManager.php
+++ b/migrations/Version202407181259241000_taoMediaManager.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoMediaManager\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+use oat\tao\scripts\SyncModels;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202407181259241000_taoMediaManager extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update Ontology models';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addReport(
+            $this->propagate(new SyncModels())([])
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration(
+            'The models should be updated via `SyncModels` script after reverting their RDF definitions.'
+        );
+    }
+}

--- a/model/MediaService.php
+++ b/model/MediaService.php
@@ -199,7 +199,11 @@ class MediaService extends ConfigurableService
         $instance = $this->getResource($id);
         $link = $this->getLink($instance);
         $fileManager = $this->getFileManager();
-        $fileManager->deleteFile($link);
+
+        if (!empty($link)) {
+            $fileManager->deleteFile($link);
+        }
+
         $link = $fileManager->storeFile($fileSource, $instance->getLabel());
 
         if ($link !== false) {

--- a/model/classes/Copier/AssetContentCopier.php
+++ b/model/classes/Copier/AssetContentCopier.php
@@ -103,7 +103,7 @@ class AssetContentCopier implements InstanceContentCopierInterface
         $stream = $this->fileManagement->getFileStream($fileInfo['link']);
         $tmpMediaPath = tempnam(sys_get_temp_dir(), 'taoMediaManager_') . '_' . $fileInfo['name'];
         $logPrefix = sprintf(
-            '[link="%s",fromLabel=%s,fromUri=%s,toLabel=%s,toUri=%s]',
+            '[link=%s,fromLabel=%s,fromUri=%s,toLabel=%s,toUri=%s]',
             $fileInfo['link'],
             $fromAsset->getLabel(),
             $fromAsset->getUri(),
@@ -114,7 +114,7 @@ class AssetContentCopier implements InstanceContentCopierInterface
         if (!file_put_contents($tmpMediaPath, $stream->getContents())) {
             throw new common_Exception(
                 sprintf(
-                    '%s Failed saving asset to a temporary file "%s"',
+                    '%s Failed saving asset to a temporary file "%s" while copying it',
                     $logPrefix,
                     $tmpMediaPath,
                 )

--- a/model/classes/Copier/AssetContentCopier.php
+++ b/model/classes/Copier/AssetContentCopier.php
@@ -60,7 +60,7 @@ class AssetContentCopier implements InstanceContentCopierInterface
         MediaService $mediaService,
         FileManagement $fileManagement,
         string $defaultLanguage,
-        MediaSource $mediaSource = null,
+        MediaSource $mediaSource = null
     ) {
         $this->sharedStimulusSpecification = $sharedStimulusResourceSpecification;
         $this->commandFactory = $commandFactory;

--- a/model/classes/ServiceProvider/MediaServiceProvider.php
+++ b/model/classes/ServiceProvider/MediaServiceProvider.php
@@ -125,6 +125,8 @@ class MediaServiceProvider implements ContainerServiceProviderInterface
                     service(SharedStimulusResourceSpecification::class),
                     service(CommandFactory::class),
                     service(CopyService::class),
+                    service(MediaService::class),
+                    service(FileManagement::SERVICE_ID),
                     DEFAULT_LANG,
                 ]
             );

--- a/model/sharedStimulus/css/service/UploadStylesheetService.php
+++ b/model/sharedStimulus/css/service/UploadStylesheetService.php
@@ -40,8 +40,21 @@ class UploadStylesheetService extends ConfigurableService
         $tmpResource = $uploadedStylesheetDTO->getFileResource();
         $size = filesize($uploadedStylesheetDTO->getTmpFileLink());
         $this->getStylesheetRepository()->putStream($link, $tmpResource);
-        fclose($tmpResource);
-        unlink($uploadedStylesheetDTO->getTmpFileLink());
+
+        if (is_resource($tmpResource)) {
+            fclose($tmpResource);
+        } else {
+            $this->logWarning(
+                sprintf(
+                    'Stream for asset stylesheet file "%s" is not valid. It may be already closed',
+                    $uploadedStylesheetDTO->getFileName()
+                )
+            );
+        }
+
+        if (is_writable($uploadedStylesheetDTO->getTmpFileLink())) {
+            unlink($uploadedStylesheetDTO->getTmpFileLink());
+        }
 
         return [
             'alt' => $uploadedStylesheetDTO->getFileName(),

--- a/test/unit/model/classes/Copier/AssetContentCopierTest.php
+++ b/test/unit/model/classes/Copier/AssetContentCopierTest.php
@@ -220,7 +220,7 @@ class AssetContentCopierTest extends TestCase
             ->willReturn(false);
 
         $this->expectExceptionMessage(
-            '[link="file_link",fromLabel=,fromUri=http://test.resources/source,toLabel=,' .
+            '[link=file_link,fromLabel=,fromUri=http://test.resources/source,toLabel=,' .
             'toUri=http://test.resources/target] Failed saving asset into filesystem while copying it'
         );
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/HKD-5
https://oat-sa.atlassian.net/browse/AUT-3754

# Goal 

- Allow to copy a single asset
- Fix error for GCP filesystem driver where if the stream was already closed, we should not try to close it again
- Address a bug introduced here https://github.com/oat-sa/extension-tao-mediamanager/pull/511/files where assets content are not copied if they are not a shared stimulus

# How to test

- Install taoMediaManager
- Click in and asset and then copy-to
- Perform a copy and the asset must be copied

# PRs

- https://github.com/oat-sa/extension-tao-deliver-connect/pull/231


![Screenshot 2024-07-18 at 17 34 04](https://github.com/user-attachments/assets/4a043b48-33ec-4a4d-88dc-be322599ec48)

![Screenshot 2024-07-18 at 17 34 26](https://github.com/user-attachments/assets/10af83c9-8ec5-4bba-ac0c-b0105144a134)

