### PR TITLE
fix: add the new area required by the item authoring to the area broker

### DIFF
--- a/views/js/qtiCreator/component/sharedStimulusAuthoring.js
+++ b/views/js/qtiCreator/component/sharedStimulusAuthoring.js
@@ -153,6 +153,7 @@ define([
                     menuRight: $container.find('.menu-right'),
                     contentCreatorPanel: $container.find('#item-editor-panel'),
                     editorBar: $container.find('#item-editor-panel .item-editor-bar'),
+                    editorWrapper: $('#item-editor-wrapper', $container),
                     title: $container.find('#item-editor-panel .item-editor-bar h1'),
                     toolbar: $container.find('#item-editor-panel .item-editor-bar #toolbar-top'),
                     interactionPanel: $container.find('#item-editor-interaction-bar'),


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1784

### Summary

https://github.com/oat-sa/extension-tao-itemqti/pull/2585 added another required area to the area broker in order to better support the side-by-side authoring. However, other consumers that rely on this area-broker also need to declare it.

### Details

Declare the required area `editorWrapper`.

### How to test

- checkout the branch: `git checkout -t origin/fix/ADF-1784/area-broker-issue`
- open a shared stimulus for authoring
