### PR TITLE
[AUT-4249]: fix form behaviour when on initial audio load CA flag wasn't shows

### DIFF
--- a/views/js/qtiCreator/widgets/static/object/states/Active.js
+++ b/views/js/qtiCreator/widgets/static/object/states/Active.js
@@ -250,6 +250,16 @@ define([
 
         $container.off('playerready').on('playerready', function () {
             setMediaSizeEditor(_widget);
+            if (isCompactAppearanceAvailable) {
+                if (/audio/.test(qtiObject.attr('type'))) {
+                    $form.find('.compact-appearance').show();
+                } else {
+                    qtiObject.attr('compact-appearance', false);
+                    $form.find('.compact-appearance').hide();
+                    $form.find('.compact-appearance input[name="compactAppearance"]').prop("checked", false);
+                    $container.parent().removeClass('compact-appearance');
+                }
+            }
         });
 
         //init data change callbacks


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/AUT-4249

## What's Changed
- Additional check when file is selected, need for show/hide compact appearance checkbox.
Also fixed part when compact appearance state is saved whenever you change source file


![chrome_6yuEZfYTCB](https://github.com/user-attachments/assets/0d8c2ba4-272a-4ed6-b5a0-d3fb1577d8b5)


> Please tick the appropriate points
- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [x] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages

## Dependencies PRs
- https://github.com/oat-sa/extension-tao-itemqti/pull/2791