### PR TITLE
fix: use basename instead of filename during export

### DIFF
--- a/model/ZipExporter.php
+++ b/model/ZipExporter.php
@@ -186,7 +186,7 @@ class ZipExporter implements tao_models_classes_export_ExportHandler
                             ->getFileStream($link);
 
                         $preparedFileContent = $this->getMediaResourcePreparer()->prepare($fileResource, $fileContent);
-                        $zip->addFromString($archivePath . $fileResource->getLabel(), $preparedFileContent);
+                        $zip->addFromString($archivePath . basename($link), $preparedFileContent);
 
                         $this->getSharedStimulusCSSExporter()->pack($fileResource, $link, $zip);
                     } catch (common_exception_UserReadableException $exception) {


### PR DESCRIPTION
## Ticket: https://oat-sa.atlassian.net/browse/ADF-574

## What's Changed
- Now stored basename from filesystem will be used instead of a label (which may be without extension) during the assets export.