### PR TITLE
fix: correct action bar icon order weights (AUT-4491)

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -19,16 +19,16 @@
                     />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="media-class-properties" name="Properties" url="/taoMediaManager/MediaManager/editClassLabel" group="content" context="class" weight="10">
+                    <action id="media-class-properties" name="Properties" url="/taoMediaManager/MediaManager/editClassLabel" group="content" context="class" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="media-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
+                    <action id="media-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="8">
                         <icon id="icon-property-add"/>
                     </action>
-                    <action id="media-properties" name="Properties"  url="/taoMediaManager/MediaManager/editInstance" group="content" context="instance" weight="10">
+                    <action id="media-properties" name="Properties"  url="/taoMediaManager/MediaManager/editInstance" group="content" context="instance" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="media-authoring" name="Authoring" url="/taoMediaManager/MediaManager/authoring" group="content" context="instance" binding="sharedStimulusAuthoring" weight="8">
+                    <action id="media-authoring" name="Authoring" url="/taoMediaManager/MediaManager/authoring" group="content" context="instance" binding="sharedStimulusAuthoring" weight="3">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="media-class-new" name="New class" url="/taoMediaManager/MediaManager/addSubClass" context="resource" group="tree" binding="subClass" weight="10">

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -19,51 +19,51 @@
                     />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="media-class-properties" name="Properties" url="/taoMediaManager/MediaManager/editClassLabel" group="content" context="class">
+                    <action id="media-class-properties" name="Properties" url="/taoMediaManager/MediaManager/editClassLabel" group="content" context="class" weight="10">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="media-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class">
+                    <action id="media-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
                         <icon id="icon-property-add"/>
                     </action>
-                    <action id="media-properties" name="Properties"  url="/taoMediaManager/MediaManager/editInstance" group="content" context="instance">
+                    <action id="media-properties" name="Properties"  url="/taoMediaManager/MediaManager/editInstance" group="content" context="instance" weight="10">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="media-authoring" name="Authoring" url="/taoMediaManager/MediaManager/authoring" group="content" context="instance" binding="sharedStimulusAuthoring">
+                    <action id="media-authoring" name="Authoring" url="/taoMediaManager/MediaManager/authoring" group="content" context="instance" binding="sharedStimulusAuthoring" weight="8">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="media-class-new" name="New class" url="/taoMediaManager/MediaManager/addSubClass" context="resource" group="tree" binding="subClass">
+                    <action id="media-class-new" name="New class" url="/taoMediaManager/MediaManager/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="media-delete" name="Delete" binding="deleteSharedStimulus" url="/taoMediaManager/MediaManager/deleteResource" context="instance" group="tree">
+                    <action id="media-delete" name="Delete" binding="deleteSharedStimulus" url="/taoMediaManager/MediaManager/deleteResource" context="instance" group="tree" weight="9">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="media-class-delete" name="Delete" binding="deleteSharedStimulus" url="/taoMediaManager/MediaManager/deleteClass" context="class" group="tree">
+                    <action id="media-class-delete" name="Delete" binding="deleteSharedStimulus" url="/taoMediaManager/MediaManager/deleteClass" context="class" group="tree" weight="9">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="media-delete-all" name="Delete" binding="removeNodes" multiple="true" url="/taoMediaManager/MediaManager/deleteAll" context="resource" group="tree">
+                    <action id="media-delete-all" name="Delete" binding="removeNodes" multiple="true" url="/taoMediaManager/MediaManager/deleteAll" context="resource" group="tree" weight="9">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="media-move" name="Move" url="/taoMediaManager/MediaManager/moveInstance" context="instance" group="none" binding="moveNode">
                         <icon id="icon-move-item"/>
                     </action>
                     <action id="media-import" name="Import" url="/taoMediaManager/MediaImport/index" group="tree"
-                            context="resource">
+                            context="resource" weight="8">
                         <icon id="icon-import"/>
                     </action>
-                    <action id="media-move-to" name="Move To" url="/taoMediaManager/MediaManager/moveResource" context="resource" group="tree" binding="moveTo">
+                    <action id="media-move-to" name="Move To" url="/taoMediaManager/MediaManager/moveResource" context="resource" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="class-copy-to" name="Copy To" url="/taoMediaManager/MediaManager/copyClass" context="class" group="tree" binding="copyClassTo">
+                    <action id="class-copy-to" name="Copy To" url="/taoMediaManager/MediaManager/copyClass" context="class" group="tree" binding="copyClassTo" weight="5">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="item-copy-to" name="Copy To" url="/taoMediaManager/MediaManager/copyInstance" context="instance" group="tree" binding="copyTo">
+                    <action id="item-copy-to" name="Copy To" url="/taoMediaManager/MediaManager/copyInstance" context="instance" group="tree" binding="copyTo" weight="5">
                         <icon id="icon-copy"/>
                     </action>
                     <action id="media-export" name="Export" url="/taoMediaManager/MediaExport/index" group="tree"
-                            context="resource">
+                            context="resource" weight="7">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="create-shared-stimulus" name="New passage" url="/taoMediaManager/SharedStimulus/create" group="tree" context="resource" binding="newSharedStimulus">
+                    <action id="create-shared-stimulus" name="New passage" url="/taoMediaManager/SharedStimulus/create" group="tree" context="resource" binding="newSharedStimulus" weight="1">
                         <icon id="icon-select-all"/>
                     </action>
                 </actions>


### PR DESCRIPTION
# fix: correct action bar icon order weights (AUT-4491)

## Summary

- Adds missing `weight` attributes to all action definitions in `structures.xml` files across affected extensions.
- Fixes incorrect icon order in the Actions menu (all tabs) when the QuickWins design feature flag is enabled.
- Root cause: `getSortedActionsByWeight()` in `tao/helpers/Layout.php` sorts ascending by weight; weights were never consistently set when weight-based sorting was introduced in AUT-3938.

## Weight conventions applied

### Tree actions (lower = leftmost)
| Weight | Action type |
|--------|------------|
| 10 | New class |
| 9 | Delete (instance / class / all) |
| 8 | Import |
| 7 | Export / Publish |
| 6 | Duplicate |
| 5 | Copy To |
| 4 | Move To |
| 3 | Translate |
| 1 | New [entity] (primary create action) |

### Content actions
| Weight | Action type |
|--------|------------|
| 10 | Properties (instance / class) |
| 9 | Preview |
| 8 | Authoring |
| 7 | History |
| 6 | Usage |
| 5 | Item Statistics |
| 3 | Manage Schema |

## Impacted extensions

- `extension-tao-item` (taoItems)
- `extension-tao-itemqti` (taoQtiItem)
- `extension-tao-test` (taoTests)
- `extension-tao-testqti` (taoQtiTest)
- `extension-tao-group` (taoGroups)
- `extension-tao-testtaker` (taoTestTaker)
- `extension-tao-delivery-rdf` (taoDeliveryRdf)
- `extension-tao-deliver-connect` (taoDeliverConnect)
- `extension-tao-backoffice` (taoBackOffice)
- `extension-tao-outcomeui` (taoOutcomeUi)
- `extension-tao-proctoring` (taoProctoring)
- `extension-remote-proctoring` (remoteProctoring)
- `extension-tao-lti-consumer` (taoLtiConsumer)
- `extension-tao-testcenter` (taoTestCenter)
- `extension-tao-blueprints` (taoBlueprints)
- `extension-tao-mediamanager` (taoMediaManager)

## Testing

Enable the QuickWins design feature flag and verify the Actions toolbar icons appear in the correct order on all tabs (Items, Tests, Test-Takers, Groups, Deliveries, Results, Assets, Blueprints, Test Centers).

No code logic changes — XML `weight` attribute additions/corrections only.

## Related

- Jira: AUT-4491
- Introduced by: AUT-3938 (weight-based sort added to Layout.php)