### PR TITLE
fix: correct tree action order for AUT-4491

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -31,23 +31,23 @@
                     <action id="media-authoring" name="Authoring" url="/taoMediaManager/MediaManager/authoring" group="content" context="instance" binding="sharedStimulusAuthoring" weight="3">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="media-class-new" name="New class" url="/taoMediaManager/MediaManager/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
+                    <action id="media-class-new" name="New class" url="/taoMediaManager/MediaManager/addSubClass" context="resource" group="tree" binding="subClass" weight="1">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="media-delete" name="Delete" binding="deleteSharedStimulus" url="/taoMediaManager/MediaManager/deleteResource" context="instance" group="tree" weight="9">
+                    <action id="media-delete" name="Delete" binding="deleteSharedStimulus" url="/taoMediaManager/MediaManager/deleteResource" context="instance" group="tree" weight="2">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="media-class-delete" name="Delete" binding="deleteSharedStimulus" url="/taoMediaManager/MediaManager/deleteClass" context="class" group="tree" weight="9">
+                    <action id="media-class-delete" name="Delete" binding="deleteSharedStimulus" url="/taoMediaManager/MediaManager/deleteClass" context="class" group="tree" weight="2">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="media-delete-all" name="Delete" binding="removeNodes" multiple="true" url="/taoMediaManager/MediaManager/deleteAll" context="resource" group="tree" weight="9">
+                    <action id="media-delete-all" name="Delete" binding="removeNodes" multiple="true" url="/taoMediaManager/MediaManager/deleteAll" context="resource" group="tree" weight="2">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="media-move" name="Move" url="/taoMediaManager/MediaManager/moveInstance" context="instance" group="none" binding="moveNode">
                         <icon id="icon-move-item"/>
                     </action>
                     <action id="media-import" name="Import" url="/taoMediaManager/MediaImport/index" group="tree"
-                            context="resource" weight="8">
+                            context="resource" weight="3">
                         <icon id="icon-import"/>
                     </action>
                     <action id="media-move-to" name="Move To" url="/taoMediaManager/MediaManager/moveResource" context="resource" group="tree" binding="moveTo" weight="4">
@@ -60,10 +60,10 @@
                         <icon id="icon-copy"/>
                     </action>
                     <action id="media-export" name="Export" url="/taoMediaManager/MediaExport/index" group="tree"
-                            context="resource" weight="7">
+                            context="resource" weight="6">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="create-shared-stimulus" name="New passage" url="/taoMediaManager/SharedStimulus/create" group="tree" context="resource" binding="newSharedStimulus" weight="1">
+                    <action id="create-shared-stimulus" name="New passage" url="/taoMediaManager/SharedStimulus/create" group="tree" context="resource" binding="newSharedStimulus" weight="7">
                         <icon id="icon-select-all"/>
                     </action>
                 </actions>


### PR DESCRIPTION
## Jira issue

https://oat-sa.atlassian.net/browse/AUT-4491

## Summary

- align `tree` action weights in Media Manager to enforce deterministic action order
- keep the change scoped to `controller/structures.xml`

## What changed

- set `New class` to weight `1`
- set all `Delete` tree actions to weight `2`
- set `Import` to weight `3`
- keep `Move To` and `Copy To` at `4` and `5`
- set `Export` to weight `6`
- move `New passage` to weight `7`

## Validation

- verified XML changes in `controller/structures.xml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the order of actions in the Media Manager interface, affecting the arrangement of media operations and content creation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->